### PR TITLE
feat: support isometric exercises (sets x seconds x weight)

### DIFF
--- a/OneTrack/Models/BodyMeasurement.swift
+++ b/OneTrack/Models/BodyMeasurement.swift
@@ -14,3 +14,4 @@ final class BodyMeasurement {
         self.date = date
     }
 }
+

--- a/OneTrack/Models/Exercise.swift
+++ b/OneTrack/Models/Exercise.swift
@@ -6,13 +6,24 @@ final class Exercise {
     var name: String = ""
     var targetSets: Int = 3
     var targetReps: Int = 10
+    var isIsometric: Bool = false
+    var targetSeconds: Int = 30
     var sortOrder: Int = 0
     var plan: WorkoutPlan?
 
-    init(name: String, targetSets: Int, targetReps: Int, sortOrder: Int) {
+    init(name: String, targetSets: Int, targetReps: Int, sortOrder: Int, isIsometric: Bool = false, targetSeconds: Int = 30) {
         self.name = name
         self.targetSets = targetSets
         self.targetReps = targetReps
+        self.isIsometric = isIsometric
+        self.targetSeconds = targetSeconds
         self.sortOrder = sortOrder
+    }
+
+    var targetDisplay: String {
+        if isIsometric {
+            return "\(targetSets) x \(targetSeconds)s"
+        }
+        return "\(targetSets) x \(targetReps)"
     }
 }

--- a/OneTrack/Models/ExerciseLog.swift
+++ b/OneTrack/Models/ExerciseLog.swift
@@ -4,13 +4,15 @@ import SwiftData
 @Model
 final class ExerciseLog {
     var exerciseName: String = ""
+    var isIsometric: Bool = false
     var sortOrder: Int = 0
     var session: WorkoutSession?
     @Relationship(deleteRule: .cascade, inverse: \SetLog.exerciseLog)
     var sets: [SetLog] = []
 
-    init(exerciseName: String, sortOrder: Int) {
+    init(exerciseName: String, sortOrder: Int, isIsometric: Bool = false) {
         self.exerciseName = exerciseName
         self.sortOrder = sortOrder
+        self.isIsometric = isIsometric
     }
 }

--- a/OneTrack/Models/SetLog.swift
+++ b/OneTrack/Models/SetLog.swift
@@ -5,13 +5,15 @@ import SwiftData
 final class SetLog {
     var setNumber: Int = 0
     var reps: Int = 0
+    var seconds: Int = 0
     var weightKg: Double = 0
     var isCompleted: Bool = false
     var exerciseLog: ExerciseLog?
 
-    init(setNumber: Int, reps: Int = 0, weightKg: Double = 0) {
+    init(setNumber: Int, reps: Int = 0, seconds: Int = 0, weightKg: Double = 0) {
         self.setNumber = setNumber
         self.reps = reps
+        self.seconds = seconds
         self.weightKg = weightKg
     }
 }

--- a/OneTrack/Utilities/ExerciseDatabase.swift
+++ b/OneTrack/Utilities/ExerciseDatabase.swift
@@ -6,6 +6,21 @@ struct ExerciseTemplate: Identifiable, Hashable {
     let category: String
     let defaultSets: Int
     let defaultReps: Int
+    let isIsometric: Bool
+    let defaultSeconds: Int
+
+    init(name: String, category: String, defaultSets: Int, defaultReps: Int, isIsometric: Bool = false, defaultSeconds: Int = 30) {
+        self.name = name
+        self.category = category
+        self.defaultSets = defaultSets
+        self.defaultReps = defaultReps
+        self.isIsometric = isIsometric
+        self.defaultSeconds = defaultSeconds
+    }
+
+    var displayTarget: String {
+        isIsometric ? "\(defaultSets) x \(defaultSeconds)s" : "\(defaultSets) x \(defaultReps)"
+    }
 }
 
 struct ExerciseDatabase {
@@ -28,6 +43,7 @@ struct ExerciseDatabase {
         ExerciseTemplate(name: "Cable Rows", category: "Back", defaultSets: 3, defaultReps: 12),
         ExerciseTemplate(name: "T-Bar Rows", category: "Back", defaultSets: 4, defaultReps: 10),
         ExerciseTemplate(name: "Face Pulls", category: "Back", defaultSets: 3, defaultReps: 15),
+        ExerciseTemplate(name: "Dead Hang", category: "Back", defaultSets: 3, defaultReps: 0, isIsometric: true, defaultSeconds: 30),
 
         // Shoulders
         ExerciseTemplate(name: "Overhead Press", category: "Shoulders", defaultSets: 3, defaultReps: 10),
@@ -52,12 +68,16 @@ struct ExerciseDatabase {
         ExerciseTemplate(name: "Leg Extensions", category: "Legs", defaultSets: 3, defaultReps: 12),
         ExerciseTemplate(name: "Calf Raises", category: "Legs", defaultSets: 4, defaultReps: 15),
         ExerciseTemplate(name: "Bulgarian Split Squats", category: "Legs", defaultSets: 3, defaultReps: 10),
+        ExerciseTemplate(name: "Wall Sit", category: "Legs", defaultSets: 3, defaultReps: 0, isIsometric: true, defaultSeconds: 45),
 
         // Core
-        ExerciseTemplate(name: "Plank", category: "Core", defaultSets: 3, defaultReps: 1),
+        ExerciseTemplate(name: "Plank", category: "Core", defaultSets: 3, defaultReps: 0, isIsometric: true, defaultSeconds: 60),
         ExerciseTemplate(name: "Hanging Leg Raises", category: "Core", defaultSets: 3, defaultReps: 12),
         ExerciseTemplate(name: "Cable Crunches", category: "Core", defaultSets: 3, defaultReps: 15),
         ExerciseTemplate(name: "Ab Wheel Rollouts", category: "Core", defaultSets: 3, defaultReps: 10),
+
+        // Carry / Functional
+        ExerciseTemplate(name: "Farmer Walk", category: "Core", defaultSets: 3, defaultReps: 0, isIsometric: true, defaultSeconds: 45),
     ]
 
     static var categories: [String] {

--- a/OneTrack/Views/Workouts/ActiveWorkoutView.swift
+++ b/OneTrack/Views/Workouts/ActiveWorkoutView.swift
@@ -291,7 +291,7 @@ private struct ExerciseSectionView: View {
                     .frame(width: 36)
                 Text("PREVIOUS")
                     .frame(maxWidth: .infinity)
-                Text("REPS")
+                Text(log.isIsometric ? "SEC" : "REPS")
                     .frame(width: 100)
                 Text("KG")
                     .frame(width: 110)
@@ -306,7 +306,7 @@ private struct ExerciseSectionView: View {
             // Set rows
             ForEach(sortedSets) { setLog in
                 let prevSet = setLog.setNumber <= previousSets.count ? previousSets[setLog.setNumber - 1] : nil
-                SetRowView(setLog: setLog, previousSet: prevSet, onCompleted: onSetCompleted)
+                SetRowView(setLog: setLog, previousSet: prevSet, isIsometric: log.isIsometric, onCompleted: onSetCompleted)
 
                 if setLog.setNumber < sortedSets.count {
                     Divider()
@@ -324,10 +324,15 @@ private struct ExerciseSectionView: View {
 private struct SetRowView: View {
     @Bindable var setLog: SetLog
     let previousSet: SetLog?
+    let isIsometric: Bool
     let onCompleted: () -> Void
 
     private var isImproved: Bool {
         guard let prev = previousSet else { return false }
+        if isIsometric {
+            return setLog.weightKg > prev.weightKg ||
+                (setLog.weightKg == prev.weightKg && setLog.seconds > prev.seconds)
+        }
         return setLog.weightKg > prev.weightKg ||
             (setLog.weightKg == prev.weightKg && setLog.reps > prev.reps)
     }
@@ -345,9 +350,15 @@ private struct SetRowView: View {
             // Previous
             Group {
                 if let prev = previousSet {
-                    Text("\(prev.reps) x \(prev.weightKg.compactWeight)")
-                        .font(.caption.monospacedDigit())
-                        .foregroundStyle(.tertiary)
+                    if isIsometric {
+                        Text("\(prev.seconds)s x \(prev.weightKg.compactWeight)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.tertiary)
+                    } else {
+                        Text("\(prev.reps) x \(prev.weightKg.compactWeight)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.tertiary)
+                    }
                 } else {
                     Text("--")
                         .font(.caption)
@@ -356,17 +367,30 @@ private struct SetRowView: View {
             }
             .frame(maxWidth: .infinity)
 
-            // Reps stepper
-            StepperInput(
-                value: Binding(
-                    get: { Double(setLog.reps) },
-                    set: { setLog.reps = Int($0) }
-                ),
-                label: "",
-                step: 1,
-                range: 0...99
-            )
-            .frame(width: 100)
+            // Reps or Seconds stepper
+            if isIsometric {
+                StepperInput(
+                    value: Binding(
+                        get: { Double(setLog.seconds) },
+                        set: { setLog.seconds = Int($0) }
+                    ),
+                    label: "",
+                    step: 5,
+                    range: 0...600
+                )
+                .frame(width: 100)
+            } else {
+                StepperInput(
+                    value: Binding(
+                        get: { Double(setLog.reps) },
+                        set: { setLog.reps = Int($0) }
+                    ),
+                    label: "",
+                    step: 1,
+                    range: 0...99
+                )
+                .frame(width: 100)
+            }
 
             // Weight stepper
             StepperInput(

--- a/OneTrack/Views/Workouts/CreatePlanView.swift
+++ b/OneTrack/Views/Workouts/CreatePlanView.swift
@@ -17,7 +17,7 @@ struct CreatePlanView: View {
             _planName = State(initialValue: plan.name)
             _exercises = State(initialValue: plan.exercises
                 .sorted { $0.sortOrder < $1.sortOrder }
-                .map { EditableExercise(name: $0.name, sets: $0.targetSets, reps: $0.targetReps) }
+                .map { EditableExercise(name: $0.name, sets: $0.targetSets, reps: $0.targetReps, isIsometric: $0.isIsometric, seconds: $0.targetSeconds) }
             )
         }
     }
@@ -96,7 +96,9 @@ struct CreatePlanView: View {
                     exercises.append(EditableExercise(
                         name: template.name,
                         sets: template.defaultSets,
-                        reps: template.defaultReps
+                        reps: template.defaultReps,
+                        isIsometric: template.isIsometric,
+                        seconds: template.defaultSeconds
                     ))
                 }
             }
@@ -111,7 +113,9 @@ struct CreatePlanView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(exercise.name)
                     .font(.subheadline.bold())
-                Text("\(exercise.sets) sets x \(exercise.reps) reps")
+                Text(exercise.isIsometric
+                    ? "\(exercise.sets) sets x \(exercise.seconds)s"
+                    : "\(exercise.sets) sets x \(exercise.reps) reps")
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -140,7 +144,7 @@ struct CreatePlanView: View {
             }
             // Add new
             for (index, ex) in exercises.enumerated() {
-                let exercise = Exercise(name: ex.name, targetSets: ex.sets, targetReps: ex.reps, sortOrder: index)
+                let exercise = Exercise(name: ex.name, targetSets: ex.sets, targetReps: ex.reps, sortOrder: index, isIsometric: ex.isIsometric, targetSeconds: ex.seconds)
                 exercise.plan = plan
                 modelContext.insert(exercise)
             }
@@ -157,7 +161,7 @@ struct CreatePlanView: View {
             modelContext.insert(plan)
 
             for (index, ex) in exercises.enumerated() {
-                let exercise = Exercise(name: ex.name, targetSets: ex.sets, targetReps: ex.reps, sortOrder: index)
+                let exercise = Exercise(name: ex.name, targetSets: ex.sets, targetReps: ex.reps, sortOrder: index, isIsometric: ex.isIsometric, targetSeconds: ex.seconds)
                 exercise.plan = plan
                 modelContext.insert(exercise)
             }
@@ -175,6 +179,16 @@ struct EditableExercise: Identifiable {
     var name: String
     var sets: Int
     var reps: Int
+    var isIsometric: Bool
+    var seconds: Int
+
+    init(name: String, sets: Int, reps: Int, isIsometric: Bool = false, seconds: Int = 30) {
+        self.name = name
+        self.sets = sets
+        self.reps = reps
+        self.isIsometric = isIsometric
+        self.seconds = seconds
+    }
 }
 
 // MARK: - Exercise Picker
@@ -214,7 +228,7 @@ struct ExercisePickerView: View {
                                         Text(exercise.name)
                                             .font(.subheadline)
                                             .foregroundStyle(.primary)
-                                        Text("\(exercise.defaultSets) x \(exercise.defaultReps)")
+                                        Text(exercise.displayTarget)
                                             .font(.caption)
                                             .foregroundStyle(.secondary)
                                     }

--- a/OneTrack/Views/Workouts/WorkoutPlanListView.swift
+++ b/OneTrack/Views/Workouts/WorkoutPlanListView.swift
@@ -201,7 +201,7 @@ struct WorkoutPlanListView: View {
         let previous = findPreviousSession(for: session)
 
         for exercise in plan.exercises.sorted(by: { $0.sortOrder < $1.sortOrder }) {
-            let log = ExerciseLog(exerciseName: exercise.name, sortOrder: exercise.sortOrder)
+            let log = ExerciseLog(exerciseName: exercise.name, sortOrder: exercise.sortOrder, isIsometric: exercise.isIsometric)
             log.session = session
             modelContext.insert(log)
 
@@ -213,6 +213,7 @@ struct WorkoutPlanListView: View {
                 let setLog = SetLog(
                     setNumber: setIndex + 1,
                     reps: prevSet?.reps ?? exercise.targetReps,
+                    seconds: prevSet?.seconds ?? exercise.targetSeconds,
                     weightKg: prevSet?.weightKg ?? 0
                 )
                 setLog.exerciseLog = log

--- a/OneTrack/Views/Workouts/WorkoutSessionDetailView.swift
+++ b/OneTrack/Views/Workouts/WorkoutSessionDetailView.swift
@@ -24,7 +24,7 @@ struct WorkoutSessionDetailView: View {
                             Text("Set \(setLog.setNumber)")
                                 .font(.subheadline)
                             Spacer()
-                            Text("\(setLog.reps) reps")
+                            Text(log.isIsometric ? "\(setLog.seconds)s" : "\(setLog.reps) reps")
                                 .monospacedDigit()
                             Text("@")
                                 .foregroundStyle(.secondary)

--- a/OneTrackTests/ExerciseDatabaseTests.swift
+++ b/OneTrackTests/ExerciseDatabaseTests.swift
@@ -6,7 +6,7 @@ import Foundation
 struct ExerciseDatabaseTests {
 
     @Test func exercisesNotEmpty() {
-        #expect(ExerciseDatabase.exercises.count >= 36)
+        #expect(ExerciseDatabase.exercises.count >= 40)
     }
 
     @Test func categoriesOrder() {
@@ -40,6 +40,24 @@ struct ExerciseDatabaseTests {
         #expect(chest.count == 7)
     }
 
+    @Test func isometricExercisesExist() {
+        let iso = ExerciseDatabase.exercises.filter(\.isIsometric)
+        #expect(iso.count >= 4)
+        #expect(iso.allSatisfy { $0.defaultSeconds > 0 })
+    }
+
+    @Test func isometricDisplayTarget() {
+        let plank = ExerciseDatabase.exercises.first { $0.name == "Plank" }!
+        #expect(plank.isIsometric)
+        #expect(plank.displayTarget == "3 x 60s")
+    }
+
+    @Test func repBasedDisplayTarget() {
+        let bench = ExerciseDatabase.exercises.first { $0.name == "Bench Press" }!
+        #expect(!bench.isIsometric)
+        #expect(bench.displayTarget == "4 x 10")
+    }
+
     @Test func exercisesInInvalidCategory() {
         let results = ExerciseDatabase.exercises(in: "Nonexistent")
         #expect(results.isEmpty)
@@ -48,7 +66,11 @@ struct ExerciseDatabaseTests {
     @Test func allExercisesHaveValidDefaults() {
         for exercise in ExerciseDatabase.exercises {
             #expect(exercise.defaultSets > 0, "Exercise \(exercise.name) has invalid sets")
-            #expect(exercise.defaultReps > 0, "Exercise \(exercise.name) has invalid reps")
+            if exercise.isIsometric {
+                #expect(exercise.defaultSeconds > 0, "Isometric exercise \(exercise.name) has invalid seconds")
+            } else {
+                #expect(exercise.defaultReps > 0, "Exercise \(exercise.name) has invalid reps")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds isometric exercise support (Plank, Wall Sit, Dead Hang, Farmer Walk)
- Exercises can now track **sets x seconds x weight** in addition to sets x reps x weight
- Active workout UI switches between reps stepper and seconds stepper (+5s/-5s) based on exercise type

## Changes
- **Models**: `Exercise.isIsometric`, `Exercise.targetSeconds`, `SetLog.seconds`, `ExerciseLog.isIsometric`
- **ExerciseDatabase**: 4 new isometric exercises, `ExerciseTemplate.displayTarget`
- **ActiveWorkoutView**: Column header shows SEC/REPS, seconds stepper for iso exercises
- **CreatePlanView**: Passes isometric info through to Exercise model
- **Tests**: 3 new tests for isometric validation

## Test plan
- [x] All 49 tests pass locally
- [ ] CI passes on GitHub Actions
- [ ] Verify Plank shows "3 x 60s" in exercise picker
- [ ] Verify seconds stepper appears during active workout for iso exercises

Closes #12