### PR TITLE
feat: import workout plans from structured text

### DIFF
--- a/OneTrack/Utilities/WorkoutPlanParser.swift
+++ b/OneTrack/Utilities/WorkoutPlanParser.swift
@@ -1,0 +1,153 @@
+import Foundation
+
+struct ParsedPlan {
+    let name: String
+    let rest: Int
+    let exercises: [ParsedExercise]
+}
+
+struct ParsedExercise {
+    let name: String
+    let sets: Int
+    let reps: Int
+    let seconds: Int
+    let isIsometric: Bool
+}
+
+enum PlanParseError: Error, LocalizedError {
+    case emptyInput
+    case missingPlanName(lineNumber: Int)
+    case invalidExerciseFormat(line: String, lineNumber: Int)
+    case noExercisesInPlan(planName: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyInput:
+            return "Input is empty"
+        case .missingPlanName(let line):
+            return "Missing plan name at line \(line)"
+        case .invalidExerciseFormat(let line, let lineNumber):
+            return "Invalid exercise format at line \(lineNumber): \"\(line)\""
+        case .noExercisesInPlan(let name):
+            return "Plan \"\(name)\" has no exercises"
+        }
+    }
+}
+
+struct WorkoutPlanParser {
+
+    /// Parses a multi-plan text format into structured plan data.
+    ///
+    /// Format:
+    /// ```
+    /// ---
+    /// name: Push Day
+    /// rest: 90
+    ///
+    /// - Bench Press: 4x10
+    /// - Plank: 3x60s
+    /// ```
+    static func parse(_ text: String) throws -> [ParsedPlan] {
+        let lines = text.components(separatedBy: .newlines)
+        guard !lines.allSatisfy({ $0.trimmingCharacters(in: .whitespaces).isEmpty }) else {
+            throw PlanParseError.emptyInput
+        }
+
+        var plans: [ParsedPlan] = []
+        var currentName: String?
+        var currentRest = 90
+        var currentExercises: [ParsedExercise] = []
+        var lineNumber = 0
+
+        func finalizePlan() throws {
+            if let name = currentName {
+                guard !currentExercises.isEmpty else {
+                    throw PlanParseError.noExercisesInPlan(planName: name)
+                }
+                plans.append(ParsedPlan(name: name, rest: currentRest, exercises: currentExercises))
+            }
+        }
+
+        for line in lines {
+            lineNumber += 1
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed == "---" {
+                try finalizePlan()
+                currentName = nil
+                currentRest = 90
+                currentExercises = []
+                continue
+            }
+
+            if trimmed.isEmpty { continue }
+
+            if trimmed.lowercased().hasPrefix("name:") {
+                currentName = String(trimmed.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                continue
+            }
+
+            if trimmed.lowercased().hasPrefix("rest:") {
+                let value = String(trimmed.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                currentRest = Int(value) ?? 90
+                continue
+            }
+
+            if trimmed.hasPrefix("-") || trimmed.hasPrefix("•") {
+                if currentName == nil {
+                    currentName = "Imported Plan"
+                }
+
+                let exerciseLine = String(trimmed.dropFirst(1)).trimmingCharacters(in: .whitespaces)
+                let exercise = try parseExercise(exerciseLine, lineNumber: lineNumber)
+                currentExercises.append(exercise)
+                continue
+            }
+
+            // If line doesn't match any pattern and there's no current plan, treat as plan name
+            if currentName == nil && !trimmed.isEmpty {
+                currentName = trimmed
+            }
+        }
+
+        try finalizePlan()
+        return plans
+    }
+
+    static func parseExercise(_ line: String, lineNumber: Int) throws -> ParsedExercise {
+        // Format: "Exercise Name: SETSxREPS" or "Exercise Name: SETSxSECONDSs"
+        guard let colonIndex = line.lastIndex(of: ":") else {
+            throw PlanParseError.invalidExerciseFormat(line: line, lineNumber: lineNumber)
+        }
+
+        let name = String(line[line.startIndex..<colonIndex]).trimmingCharacters(in: .whitespaces)
+        let spec = String(line[line.index(after: colonIndex)...]).trimmingCharacters(in: .whitespaces)
+
+        guard !name.isEmpty else {
+            throw PlanParseError.invalidExerciseFormat(line: line, lineNumber: lineNumber)
+        }
+
+        // Parse "4x10" or "3x60s"
+        let parts = spec.lowercased().split(separator: "x")
+        guard parts.count == 2, let sets = Int(parts[0]) else {
+            throw PlanParseError.invalidExerciseFormat(line: line, lineNumber: lineNumber)
+        }
+
+        let valuePart = String(parts[1])
+
+        if valuePart.hasSuffix("s") {
+            // Isometric: "60s"
+            let secondsStr = String(valuePart.dropLast())
+            guard let seconds = Int(secondsStr) else {
+                throw PlanParseError.invalidExerciseFormat(line: line, lineNumber: lineNumber)
+            }
+            return ParsedExercise(name: name, sets: sets, reps: 0, seconds: seconds, isIsometric: true)
+        } else {
+            // Rep-based: "10"
+            guard let reps = Int(valuePart) else {
+                throw PlanParseError.invalidExerciseFormat(line: line, lineNumber: lineNumber)
+            }
+            return ParsedExercise(name: name, sets: sets, reps: reps, seconds: 0, isIsometric: false)
+        }
+    }
+}

--- a/OneTrack/Views/Workouts/ImportPlanView.swift
+++ b/OneTrack/Views/Workouts/ImportPlanView.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+import SwiftData
+import UniformTypeIdentifiers
+
+struct ImportPlanView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var inputText = ""
+    @State private var parsedPlans: [ParsedPlan] = []
+    @State private var parseError: String?
+    @State private var showFileImporter = false
+    @State private var imported = false
+
+    var body: some View {
+        List {
+            Section {
+                TextEditor(text: $inputText)
+                    .font(.system(.caption, design: .monospaced))
+                    .frame(minHeight: 200)
+                    .overlay(alignment: .topLeading) {
+                        if inputText.isEmpty {
+                            Text(placeholderText)
+                                .font(.system(.caption, design: .monospaced))
+                                .foregroundStyle(.tertiary)
+                                .padding(.top, 8)
+                                .padding(.leading, 4)
+                                .allowsHitTesting(false)
+                        }
+                    }
+            } header: {
+                HStack {
+                    Text("Paste your workout plan")
+                    Spacer()
+                    Button("From File") {
+                        showFileImporter = true
+                    }
+                    .font(.caption)
+                }
+            } footer: {
+                Text("Format: `- Exercise Name: SETSxREPS` or `- Exercise Name: SETSxSECONDSs` for isometric")
+                    .font(.caption2)
+            }
+
+            if let parseError {
+                Section {
+                    Label(parseError, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                        .font(.caption)
+                }
+            }
+
+            if !parsedPlans.isEmpty {
+                ForEach(Array(parsedPlans.enumerated()), id: \.offset) { _, plan in
+                    Section(plan.name) {
+                        ForEach(Array(plan.exercises.enumerated()), id: \.offset) { _, exercise in
+                            HStack {
+                                Text(exercise.name)
+                                    .font(.subheadline)
+                                Spacer()
+                                if exercise.isIsometric {
+                                    Text("\(exercise.sets)x\(exercise.seconds)s")
+                                        .font(.caption.monospacedDigit())
+                                        .foregroundStyle(.orange)
+                                } else {
+                                    Text("\(exercise.sets)x\(exercise.reps)")
+                                        .font(.caption.monospacedDigit())
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+
+                        if plan.rest != 90 {
+                            HStack {
+                                Text("Rest timer")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Spacer()
+                                Text("\(plan.rest)s")
+                                    .font(.caption.monospacedDigit())
+                                    .foregroundStyle(.secondary)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Import Workout")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button("Cancel") { dismiss() }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                if parsedPlans.isEmpty {
+                    Button("Preview") { preview() }
+                        .bold()
+                        .disabled(inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                } else {
+                    Button("Import (\(parsedPlans.count))") { importPlans() }
+                        .bold()
+                }
+            }
+        }
+        .fileImporter(isPresented: $showFileImporter, allowedContentTypes: [.plainText]) { result in
+            if case .success(let url) = result {
+                if url.startAccessingSecurityScopedResource() {
+                    defer { url.stopAccessingSecurityScopedResource() }
+                    if let text = try? String(contentsOf: url, encoding: .utf8) {
+                        inputText = text
+                    }
+                }
+            }
+        }
+    }
+
+    private func preview() {
+        parseError = nil
+        parsedPlans = []
+        do {
+            parsedPlans = try WorkoutPlanParser.parse(inputText)
+        } catch {
+            parseError = error.localizedDescription
+        }
+    }
+
+    private func importPlans() {
+        let descriptor = FetchDescriptor<WorkoutPlan>(sortBy: [SortDescriptor(\.sortOrder, order: .reverse)])
+        var nextOrder = ((try? modelContext.fetch(descriptor).first?.sortOrder) ?? -1) + 1
+
+        for parsed in parsedPlans {
+            let plan = WorkoutPlan(
+                name: parsed.name,
+                planDescription: "",
+                sortOrder: nextOrder,
+                defaultRestSeconds: parsed.rest
+            )
+            modelContext.insert(plan)
+
+            for (index, ex) in parsed.exercises.enumerated() {
+                let exercise = Exercise(
+                    name: ex.name,
+                    targetSets: ex.sets,
+                    targetReps: ex.reps,
+                    sortOrder: index,
+                    isIsometric: ex.isIsometric,
+                    targetSeconds: ex.seconds
+                )
+                exercise.plan = plan
+                modelContext.insert(exercise)
+            }
+            nextOrder += 1
+        }
+
+        try? modelContext.save()
+        dismiss()
+    }
+
+    private var placeholderText: String {
+        """
+        ---
+        name: Push Day
+        rest: 90
+
+        - Bench Press: 4x10
+        - Overhead Press: 3x10
+        - Lateral Raises: 3x15
+
+        ---
+        name: Pull Day
+
+        - Deadlift: 4x6
+        - Barbell Rows: 4x10
+        - Plank: 3x60s
+        """
+    }
+}

--- a/OneTrack/Views/Workouts/WorkoutsTabView.swift
+++ b/OneTrack/Views/Workouts/WorkoutsTabView.swift
@@ -4,6 +4,7 @@ import SwiftData
 struct WorkoutsTabView: View {
     @State private var showingHistory = false
     @State private var showingCreatePlan = false
+    @State private var showingImport = false
 
     var body: some View {
         NavigationStack {
@@ -16,8 +17,19 @@ struct WorkoutsTabView: View {
                         }
                     }
                     ToolbarItem(placement: .topBarTrailing) {
-                        Button("New", systemImage: "plus") {
-                            showingCreatePlan = true
+                        Menu {
+                            Button {
+                                showingCreatePlan = true
+                            } label: {
+                                Label("New Workout", systemImage: "plus")
+                            }
+                            Button {
+                                showingImport = true
+                            } label: {
+                                Label("Import from Text", systemImage: "doc.text")
+                            }
+                        } label: {
+                            Image(systemName: "plus")
                         }
                     }
                 }
@@ -35,6 +47,11 @@ struct WorkoutsTabView: View {
                 .sheet(isPresented: $showingCreatePlan) {
                     NavigationStack {
                         CreatePlanView()
+                    }
+                }
+                .sheet(isPresented: $showingImport) {
+                    NavigationStack {
+                        ImportPlanView()
                     }
                 }
         }

--- a/OneTrackTests/WorkoutPlanParserTests.swift
+++ b/OneTrackTests/WorkoutPlanParserTests.swift
@@ -1,0 +1,209 @@
+import Testing
+import Foundation
+@testable import OneTrack
+
+@Suite("Workout Plan Parser")
+struct WorkoutPlanParserTests {
+
+    @Test func parseSinglePlan() throws {
+        let input = """
+        ---
+        name: Push Day
+
+        - Bench Press: 4x10
+        - Overhead Press: 3x10
+        """
+        let plans = try WorkoutPlanParser.parse(input)
+        #expect(plans.count == 1)
+        #expect(plans[0].name == "Push Day")
+        #expect(plans[0].exercises.count == 2)
+        #expect(plans[0].exercises[0].name == "Bench Press")
+        #expect(plans[0].exercises[0].sets == 4)
+        #expect(plans[0].exercises[0].reps == 10)
+        #expect(!plans[0].exercises[0].isIsometric)
+    }
+
+    @Test func parseMultiplePlans() throws {
+        let input = """
+        ---
+        name: Push
+
+        - Bench Press: 4x10
+
+        ---
+        name: Pull
+
+        - Deadlift: 4x6
+        - Barbell Rows: 4x10
+        """
+        let plans = try WorkoutPlanParser.parse(input)
+        #expect(plans.count == 2)
+        #expect(plans[0].name == "Push")
+        #expect(plans[1].name == "Pull")
+        #expect(plans[1].exercises.count == 2)
+    }
+
+    @Test func parseRestTimer() throws {
+        let input = """
+        ---
+        name: Heavy Day
+        rest: 180
+
+        - Squats: 5x5
+        """
+        let plans = try WorkoutPlanParser.parse(input)
+        #expect(plans[0].rest == 180)
+    }
+
+    @Test func parseDefaultRest() throws {
+        let input = """
+        ---
+        name: Light Day
+
+        - Curls: 3x12
+        """
+        let plans = try WorkoutPlanParser.parse(input)
+        #expect(plans[0].rest == 90)
+    }
+
+    @Test func parseIsometricExercise() throws {
+        let input = """
+        ---
+        name: Core
+
+        - Plank: 3x60s
+        - Crunches: 3x15
+        """
+        let plans = try WorkoutPlanParser.parse(input)
+        #expect(plans[0].exercises[0].isIsometric)
+        #expect(plans[0].exercises[0].seconds == 60)
+        #expect(plans[0].exercises[0].reps == 0)
+        #expect(!plans[0].exercises[1].isIsometric)
+        #expect(plans[0].exercises[1].reps == 15)
+    }
+
+    @Test func parseWithoutSeparator() throws {
+        let input = """
+        name: Quick Workout
+
+        - Push-ups: 3x20
+        """
+        let plans = try WorkoutPlanParser.parse(input)
+        #expect(plans.count == 1)
+        #expect(plans[0].name == "Quick Workout")
+    }
+
+    @Test func parseBulletPointFormat() throws {
+        let input = """
+        ---
+        name: Test
+
+        • Bench Press: 4x10
+        • Squats: 4x8
+        """
+        let plans = try WorkoutPlanParser.parse(input)
+        #expect(plans[0].exercises.count == 2)
+    }
+
+    @Test func emptyInputThrows() {
+        #expect(throws: PlanParseError.self) {
+            try WorkoutPlanParser.parse("")
+        }
+    }
+
+    @Test func whitespaceOnlyThrows() {
+        #expect(throws: PlanParseError.self) {
+            try WorkoutPlanParser.parse("   \n   \n   ")
+        }
+    }
+
+    @Test func invalidExerciseFormatThrows() {
+        let input = """
+        ---
+        name: Bad Plan
+
+        - No colon here
+        """
+        #expect(throws: PlanParseError.self) {
+            try WorkoutPlanParser.parse(input)
+        }
+    }
+
+    @Test func planWithNoExercisesThrows() {
+        let input = """
+        ---
+        name: Empty Plan
+        ---
+        name: Good Plan
+
+        - Bench: 4x10
+        """
+        #expect(throws: PlanParseError.self) {
+            try WorkoutPlanParser.parse(input)
+        }
+    }
+
+    @Test func parseExerciseDirectly() throws {
+        let exercise = try WorkoutPlanParser.parseExercise("Bench Press: 4x10", lineNumber: 1)
+        #expect(exercise.name == "Bench Press")
+        #expect(exercise.sets == 4)
+        #expect(exercise.reps == 10)
+    }
+
+    @Test func parseIsometricExerciseDirectly() throws {
+        let exercise = try WorkoutPlanParser.parseExercise("Plank: 3x60s", lineNumber: 1)
+        #expect(exercise.name == "Plank")
+        #expect(exercise.sets == 3)
+        #expect(exercise.seconds == 60)
+        #expect(exercise.isIsometric)
+    }
+
+    @Test func parseExerciseWithExtraSpaces() throws {
+        let exercise = try WorkoutPlanParser.parseExercise("  Bench Press  :  4x10  ", lineNumber: 1)
+        #expect(exercise.name == "Bench Press")
+        #expect(exercise.sets == 4)
+    }
+
+    @Test func fullRealisticImport() throws {
+        let input = """
+        ---
+        name: Push Day A
+        rest: 90
+
+        - Bench Press: 4x10
+        - Overhead Press: 3x10
+        - Incline Dumbbell Press: 3x12
+        - Lateral Raises: 3x15
+        - Tricep Pushdowns: 3x12
+
+        ---
+        name: Pull Day A
+        rest: 120
+
+        - Deadlift: 4x6
+        - Barbell Rows: 4x10
+        - Lat Pulldowns: 3x12
+        - Face Pulls: 3x15
+        - Barbell Curls: 3x12
+
+        ---
+        name: Legs + Core
+        rest: 120
+
+        - Squats: 4x8
+        - Romanian Deadlift: 3x10
+        - Leg Press: 3x12
+        - Calf Raises: 4x15
+        - Plank: 3x60s
+        """
+        let plans = try WorkoutPlanParser.parse(input)
+        #expect(plans.count == 3)
+        #expect(plans[0].exercises.count == 5)
+        #expect(plans[1].exercises.count == 5)
+        #expect(plans[2].exercises.count == 5)
+        #expect(plans[2].exercises[4].isIsometric)
+        #expect(plans[2].exercises[4].seconds == 60)
+        #expect(plans[0].rest == 90)
+        #expect(plans[1].rest == 120)
+    }
+}


### PR DESCRIPTION
## Summary
- Users can import multiple workout plans at once by pasting structured text or loading a .txt file
- Supports the format defined in #10, including isometric exercises

## Format Example
```
---
name: Push Day
rest: 90

- Bench Press: 4x10
- Overhead Press: 3x10
- Plank: 3x60s
```

## Changes
- **WorkoutPlanParser**: Standalone parser with full error handling
- **ImportPlanView**: Text editor with file import, preview, and confirm flow
- **WorkoutsTabView**: "+" button now opens menu with "New Workout" and "Import from Text"
- **15 new parser tests**: Single/multi plan, isometric, rest timer, error cases, realistic import

## Test plan
- [x] 68 tests pass locally (0 failures)
- [ ] CI passes
- [ ] Paste a multi-plan text, verify preview shows correct plans
- [ ] Import from .txt file via Files app
- [ ] Verify imported plans appear in the plan list

Closes #10

Depends on #13 (isometric) and #14 (custom exercises)