### PR TITLE
feat: workout UX improvements — reorder, edit, add mid-workout, fix iso display

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,8 @@ A personal all-in-one fitness and health tracking iOS app built with Swift/Swift
 For each feature or bug fix:
 
 1. **Pick an issue** from [GitHub Issues](https://github.com/amitwitk/OneTrack/issues) — labeled by domain (`workout`, `nutrition`, `body`, `activity`, `dashboard`)
-2. **Create a branch** from `main` — `feat/<name>` or `fix/<name>`
+2. **Pull latest main** — `git checkout main && git pull origin main`
+3. **Create a branch** from `main` — `feat/<name>` or `fix/<name>`
 3. **Plan** the implementation (identify models, views, and dependencies)
 4. **Implement** with clean, testable code — extract logic into standalone functions/structs for testability
 5. **Add tests** — unit tests using Swift Testing framework, in-memory SwiftData containers, aim for coverage on all new logic

--- a/OneTrack/Views/Workouts/ActiveWorkoutView.swift
+++ b/OneTrack/Views/Workouts/ActiveWorkoutView.swift
@@ -11,6 +11,7 @@ struct ActiveWorkoutView: View {
     @State private var isTimerRunning = true
     @State private var showFinishConfirmation = false
     @State private var showCancelConfirmation = false
+    @State private var showAddExercise = false
 
     // Rest timer
     @State private var restTimeRemaining: Int = 0
@@ -45,6 +46,20 @@ struct ActiveWorkoutView: View {
                             onSetCompleted: { startRestTimer() }
                         )
                     }
+
+                    // Add exercise mid-workout
+                    Button {
+                        showAddExercise = true
+                    } label: {
+                        Label("Add Exercise", systemImage: "plus.circle")
+                            .font(.subheadline)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(.background, in: RoundedRectangle(cornerRadius: 12))
+                            .shadow(color: .black.opacity(0.04), radius: 4, y: 2)
+                    }
+                    .buttonStyle(.plain)
+
                     Color.clear.frame(height: isResting ? 80 : 0)
                 }
                 .padding()
@@ -96,6 +111,11 @@ struct ActiveWorkoutView: View {
         }
         .onAppear {
             restDuration = session.plan?.defaultRestSeconds ?? 90
+        }
+        .sheet(isPresented: $showAddExercise) {
+            ExercisePickerView { templates in
+                addExercises(templates)
+            }
         }
         .task(id: "workout-timer") {
             while isTimerRunning && !Task.isCancelled {
@@ -219,6 +239,31 @@ struct ActiveWorkoutView: View {
     }
 
     // MARK: - Actions
+
+    private func addExercises(_ templates: [ExerciseTemplate]) {
+        let maxOrder = sortedLogs.last?.sortOrder ?? -1
+        for (index, template) in templates.enumerated() {
+            let log = ExerciseLog(
+                exerciseName: template.name,
+                sortOrder: maxOrder + 1 + index,
+                isIsometric: template.isIsometric
+            )
+            log.session = session
+            modelContext.insert(log)
+
+            for setIndex in 0..<template.defaultSets {
+                let setLog = SetLog(
+                    setNumber: setIndex + 1,
+                    reps: template.defaultReps,
+                    seconds: template.defaultSeconds,
+                    weightKg: 0
+                )
+                setLog.exerciseLog = log
+                modelContext.insert(setLog)
+            }
+        }
+        try? modelContext.save()
+    }
 
     private func startRestTimer() {
         restTimeRemaining = restDuration

--- a/OneTrack/Views/Workouts/WorkoutPlanDetailView.swift
+++ b/OneTrack/Views/Workouts/WorkoutPlanDetailView.swift
@@ -3,6 +3,8 @@ import SwiftData
 
 struct WorkoutPlanDetailView: View {
     let plan: WorkoutPlan
+    @Environment(\.modelContext) private var modelContext
+    @State private var exerciseToEdit: Exercise?
 
     private var sortedExercises: [Exercise] {
         plan.exercises.sorted { $0.sortOrder < $1.sortOrder }
@@ -14,32 +16,40 @@ struct WorkoutPlanDetailView: View {
 
     var body: some View {
         List {
-            // Exercises
             Section("Exercises") {
-                ForEach(Array(sortedExercises.enumerated()), id: \.element.id) { index, exercise in
-                    HStack(spacing: 12) {
-                        Text("\(index + 1)")
-                            .font(.caption.bold())
-                            .foregroundStyle(.white)
-                            .frame(width: 24, height: 24)
-                            .background(.blue, in: Circle())
+                ForEach(sortedExercises) { exercise in
+                    Button {
+                        exerciseToEdit = exercise
+                    } label: {
+                        HStack(spacing: 12) {
+                            Text(exercise.name)
+                                .foregroundStyle(.primary)
 
-                        Text(exercise.name)
+                            Spacer()
 
-                        Spacer()
+                            Text(exercise.targetDisplay)
+                                .foregroundStyle(.secondary)
+                                .font(.subheadline.monospacedDigit())
 
-                        Text("\(exercise.targetSets) x \(exercise.targetReps)")
-                            .foregroundStyle(.secondary)
-                            .font(.subheadline.monospacedDigit())
+                            Image(systemName: "chevron.right")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
                     }
+                }
+                .onMove { from, to in
+                    var exercises = sortedExercises
+                    exercises.move(fromOffsets: from, toOffset: to)
+                    for (index, exercise) in exercises.enumerated() {
+                        exercise.sortOrder = index
+                    }
+                    try? modelContext.save()
                 }
             }
 
-            // Stats
             if !completedSessions.isEmpty {
                 Section("Stats") {
                     LabeledContent("Total Sessions", value: "\(completedSessions.count)")
-
                     if let lastSession = completedSessions.first {
                         LabeledContent("Last Workout", value: lastSession.date.shortDate)
                         if let d = lastSession.durationSeconds {
@@ -49,7 +59,6 @@ struct WorkoutPlanDetailView: View {
                 }
             }
 
-            // Recent history
             if !completedSessions.isEmpty {
                 Section("Recent Sessions") {
                     ForEach(completedSessions.prefix(5)) { session in
@@ -76,5 +85,63 @@ struct WorkoutPlanDetailView: View {
             }
         }
         .navigationTitle(plan.name)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                EditButton()
+            }
+        }
+        .sheet(item: $exerciseToEdit) { exercise in
+            NavigationStack {
+                EditExerciseView(exercise: exercise)
+            }
+        }
+    }
+}
+
+// MARK: - Edit Exercise Sheet
+
+struct EditExerciseView: View {
+    @Bindable var exercise: Exercise
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.modelContext) private var modelContext
+
+    var body: some View {
+        Form {
+            Section("Exercise") {
+                Text(exercise.name)
+                    .font(.headline)
+            }
+
+            Section("Sets & Reps") {
+                Stepper("Sets: \(exercise.targetSets)", value: $exercise.targetSets, in: 1...10)
+
+                if exercise.isIsometric {
+                    Stepper("Seconds: \(exercise.targetSeconds)", value: $exercise.targetSeconds, in: 5...300, step: 5)
+                } else {
+                    Stepper("Reps: \(exercise.targetReps)", value: $exercise.targetReps, in: 1...100)
+                }
+            }
+
+            Section {
+                HStack {
+                    Text("Target")
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Text(exercise.targetDisplay)
+                        .font(.subheadline.bold().monospacedDigit())
+                }
+            }
+        }
+        .navigationTitle("Edit Exercise")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Done") {
+                    try? modelContext.save()
+                    dismiss()
+                }
+                .bold()
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
4 workout UX improvements in one PR:

- **#22 Reorder exercises**: Edit button in plan detail view enables drag-to-reorder
- **#23 Add exercise mid-workout**: "Add Exercise" button at bottom of active workout opens exercise picker, adds exercises to current session only (doesn't modify the plan)
- **#24 Edit sets/reps**: Tap any exercise in plan detail to edit sets/reps/seconds via a sheet with steppers
- **#25 Fix iso display**: Plan detail now uses `exercise.targetDisplay` to show "3 x 60s" for isometric exercises instead of "3 x 0"

Also updates CLAUDE.md workflow to include "pull latest main" step.

## Test plan
- [x] 68 tests pass locally
- [ ] CI passes
- [ ] Tap exercise in plan detail → edit sets → verify saved
- [ ] Edit mode → drag to reorder → verify order persists
- [ ] During active workout → Add Exercise → verify new exercise appears
- [ ] Create plan with Plank → verify "3 x 60s" in plan detail (not "3 x 0")

Closes #22 #23 #24 #25