### PR TITLE
feat: exercise groups, sorting, edit, add mid-workout, fix iso display

### DIFF
--- a/OneTrack/Models/Exercise.swift
+++ b/OneTrack/Models/Exercise.swift
@@ -8,16 +8,18 @@ final class Exercise {
     var targetReps: Int = 10
     var isIsometric: Bool = false
     var targetSeconds: Int = 30
+    var section: String = ""
     var sortOrder: Int = 0
     var plan: WorkoutPlan?
 
-    init(name: String, targetSets: Int, targetReps: Int, sortOrder: Int, isIsometric: Bool = false, targetSeconds: Int = 30) {
+    init(name: String, targetSets: Int, targetReps: Int, sortOrder: Int, isIsometric: Bool = false, targetSeconds: Int = 30, section: String = "") {
         self.name = name
         self.targetSets = targetSets
         self.targetReps = targetReps
         self.isIsometric = isIsometric
         self.targetSeconds = targetSeconds
         self.sortOrder = sortOrder
+        self.section = section
     }
 
     var targetDisplay: String {

--- a/OneTrack/Models/ExerciseLog.swift
+++ b/OneTrack/Models/ExerciseLog.swift
@@ -5,14 +5,16 @@ import SwiftData
 final class ExerciseLog {
     var exerciseName: String = ""
     var isIsometric: Bool = false
+    var section: String = ""
     var sortOrder: Int = 0
     var session: WorkoutSession?
     @Relationship(deleteRule: .cascade, inverse: \SetLog.exerciseLog)
     var sets: [SetLog] = []
 
-    init(exerciseName: String, sortOrder: Int, isIsometric: Bool = false) {
+    init(exerciseName: String, sortOrder: Int, isIsometric: Bool = false, section: String = "") {
         self.exerciseName = exerciseName
         self.sortOrder = sortOrder
         self.isIsometric = isIsometric
+        self.section = section
     }
 }

--- a/OneTrack/Utilities/WorkoutPlanParser.swift
+++ b/OneTrack/Utilities/WorkoutPlanParser.swift
@@ -12,6 +12,7 @@ struct ParsedExercise {
     let reps: Int
     let seconds: Int
     let isIsometric: Bool
+    let section: String
 }
 
 enum PlanParseError: Error, LocalizedError {
@@ -57,6 +58,7 @@ struct WorkoutPlanParser {
         var currentName: String?
         var currentRest = 90
         var currentExercises: [ParsedExercise] = []
+        var currentSection = ""
         var lineNumber = 0
 
         func finalizePlan() throws {
@@ -77,6 +79,7 @@ struct WorkoutPlanParser {
                 currentName = nil
                 currentRest = 90
                 currentExercises = []
+                currentSection = ""
                 continue
             }
 
@@ -93,13 +96,19 @@ struct WorkoutPlanParser {
                 continue
             }
 
+            // Section header: [Section Name]
+            if trimmed.hasPrefix("[") && trimmed.hasSuffix("]") {
+                currentSection = String(trimmed.dropFirst().dropLast()).trimmingCharacters(in: .whitespaces)
+                continue
+            }
+
             if trimmed.hasPrefix("-") || trimmed.hasPrefix("•") {
                 if currentName == nil {
                     currentName = "Imported Plan"
                 }
 
                 let exerciseLine = String(trimmed.dropFirst(1)).trimmingCharacters(in: .whitespaces)
-                let exercise = try parseExercise(exerciseLine, lineNumber: lineNumber)
+                let exercise = try parseExercise(exerciseLine, lineNumber: lineNumber, section: currentSection)
                 currentExercises.append(exercise)
                 continue
             }
@@ -114,7 +123,7 @@ struct WorkoutPlanParser {
         return plans
     }
 
-    static func parseExercise(_ line: String, lineNumber: Int) throws -> ParsedExercise {
+    static func parseExercise(_ line: String, lineNumber: Int, section: String = "") throws -> ParsedExercise {
         // Format: "Exercise Name: SETSxREPS" or "Exercise Name: SETSxSECONDSs"
         guard let colonIndex = line.lastIndex(of: ":") else {
             throw PlanParseError.invalidExerciseFormat(line: line, lineNumber: lineNumber)
@@ -141,13 +150,13 @@ struct WorkoutPlanParser {
             guard let seconds = Int(secondsStr) else {
                 throw PlanParseError.invalidExerciseFormat(line: line, lineNumber: lineNumber)
             }
-            return ParsedExercise(name: name, sets: sets, reps: 0, seconds: seconds, isIsometric: true)
+            return ParsedExercise(name: name, sets: sets, reps: 0, seconds: seconds, isIsometric: true, section: section)
         } else {
             // Rep-based: "10"
             guard let reps = Int(valuePart) else {
                 throw PlanParseError.invalidExerciseFormat(line: line, lineNumber: lineNumber)
             }
-            return ParsedExercise(name: name, sets: sets, reps: reps, seconds: 0, isIsometric: false)
+            return ParsedExercise(name: name, sets: sets, reps: reps, seconds: 0, isIsometric: false, section: section)
         }
     }
 }

--- a/OneTrack/Views/Workouts/ActiveWorkoutView.swift
+++ b/OneTrack/Views/Workouts/ActiveWorkoutView.swift
@@ -22,6 +22,20 @@ struct ActiveWorkoutView: View {
         session.exerciseLogs.sorted { $0.sortOrder < $1.sortOrder }
     }
 
+    private var groupedLogs: [(String, [ExerciseLog])] {
+        var result: [(String, [ExerciseLog])] = []
+        var currentSection = "\u{0}" // impossible sentinel
+        for log in sortedLogs {
+            if log.section != currentSection {
+                currentSection = log.section
+                result.append((currentSection, [log]))
+            } else {
+                result[result.count - 1].1.append(log)
+            }
+        }
+        return result
+    }
+
     private var completedCount: Int {
         sortedLogs.flatMap(\.sets).filter(\.isCompleted).count
     }
@@ -39,12 +53,21 @@ struct ActiveWorkoutView: View {
             ScrollView {
                 VStack(spacing: 16) {
                     headerCard
-                    ForEach(sortedLogs) { log in
-                        ExerciseSectionView(
-                            log: log,
-                            previousSession: previousSession,
-                            onSetCompleted: { startRestTimer() }
-                        )
+                    ForEach(groupedLogs, id: \.0) { sectionName, logs in
+                        if !sectionName.isEmpty {
+                            Text(sectionName)
+                                .font(.subheadline.bold())
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.top, 4)
+                        }
+                        ForEach(logs) { log in
+                            ExerciseSectionView(
+                                log: log,
+                                previousSession: previousSession,
+                                onSetCompleted: { startRestTimer() }
+                            )
+                        }
                     }
 
                     // Add exercise mid-workout

--- a/OneTrack/Views/Workouts/CreatePlanView.swift
+++ b/OneTrack/Views/Workouts/CreatePlanView.swift
@@ -17,7 +17,7 @@ struct CreatePlanView: View {
             _planName = State(initialValue: plan.name)
             _exercises = State(initialValue: plan.exercises
                 .sorted { $0.sortOrder < $1.sortOrder }
-                .map { EditableExercise(name: $0.name, sets: $0.targetSets, reps: $0.targetReps, isIsometric: $0.isIsometric, seconds: $0.targetSeconds) }
+                .map { EditableExercise(name: $0.name, sets: $0.targetSets, reps: $0.targetReps, isIsometric: $0.isIsometric, seconds: $0.targetSeconds, section: $0.section) }
             )
         }
     }
@@ -144,7 +144,7 @@ struct CreatePlanView: View {
             }
             // Add new
             for (index, ex) in exercises.enumerated() {
-                let exercise = Exercise(name: ex.name, targetSets: ex.sets, targetReps: ex.reps, sortOrder: index, isIsometric: ex.isIsometric, targetSeconds: ex.seconds)
+                let exercise = Exercise(name: ex.name, targetSets: ex.sets, targetReps: ex.reps, sortOrder: index, isIsometric: ex.isIsometric, targetSeconds: ex.seconds, section: ex.section)
                 exercise.plan = plan
                 modelContext.insert(exercise)
             }
@@ -161,7 +161,7 @@ struct CreatePlanView: View {
             modelContext.insert(plan)
 
             for (index, ex) in exercises.enumerated() {
-                let exercise = Exercise(name: ex.name, targetSets: ex.sets, targetReps: ex.reps, sortOrder: index, isIsometric: ex.isIsometric, targetSeconds: ex.seconds)
+                let exercise = Exercise(name: ex.name, targetSets: ex.sets, targetReps: ex.reps, sortOrder: index, isIsometric: ex.isIsometric, targetSeconds: ex.seconds, section: ex.section)
                 exercise.plan = plan
                 modelContext.insert(exercise)
             }
@@ -181,13 +181,15 @@ struct EditableExercise: Identifiable {
     var reps: Int
     var isIsometric: Bool
     var seconds: Int
+    var section: String
 
-    init(name: String, sets: Int, reps: Int, isIsometric: Bool = false, seconds: Int = 30) {
+    init(name: String, sets: Int, reps: Int, isIsometric: Bool = false, seconds: Int = 30, section: String = "") {
         self.name = name
         self.sets = sets
         self.reps = reps
         self.isIsometric = isIsometric
         self.seconds = seconds
+        self.section = section
     }
 }
 

--- a/OneTrack/Views/Workouts/ImportPlanView.swift
+++ b/OneTrack/Views/Workouts/ImportPlanView.swift
@@ -144,7 +144,8 @@ struct ImportPlanView: View {
                     targetReps: ex.reps,
                     sortOrder: index,
                     isIsometric: ex.isIsometric,
-                    targetSeconds: ex.seconds
+                    targetSeconds: ex.seconds,
+                    section: ex.section
                 )
                 exercise.plan = plan
                 modelContext.insert(exercise)

--- a/OneTrack/Views/Workouts/WorkoutPlanDetailView.swift
+++ b/OneTrack/Views/Workouts/WorkoutPlanDetailView.swift
@@ -5,9 +5,25 @@ struct WorkoutPlanDetailView: View {
     let plan: WorkoutPlan
     @Environment(\.modelContext) private var modelContext
     @State private var exerciseToEdit: Exercise?
+    @State private var showAddGroup = false
+    @State private var newGroupName = ""
 
     private var sortedExercises: [Exercise] {
         plan.exercises.sorted { $0.sortOrder < $1.sortOrder }
+    }
+
+    private var sections: [(String, [Exercise])] {
+        let grouped = Dictionary(grouping: sortedExercises, by: \.section)
+        var sectionOrder: [String] = []
+        for exercise in sortedExercises {
+            if !sectionOrder.contains(exercise.section) {
+                sectionOrder.append(exercise.section)
+            }
+        }
+        return sectionOrder.compactMap { section in
+            guard let exercises = grouped[section] else { return nil }
+            return (section, exercises)
+        }
     }
 
     private var completedSessions: [WorkoutSession] {
@@ -16,37 +32,48 @@ struct WorkoutPlanDetailView: View {
 
     var body: some View {
         List {
-            Section("Exercises") {
-                ForEach(sortedExercises) { exercise in
-                    Button {
-                        exerciseToEdit = exercise
-                    } label: {
-                        HStack(spacing: 12) {
-                            Text(exercise.name)
-                                .foregroundStyle(.primary)
-
-                            Spacer()
-
-                            Text(exercise.targetDisplay)
-                                .foregroundStyle(.secondary)
-                                .font(.subheadline.monospacedDigit())
-
-                            Image(systemName: "chevron.right")
-                                .font(.caption2)
-                                .foregroundStyle(.tertiary)
+            // Exercise sections
+            ForEach(sections, id: \.0) { sectionName, exercises in
+                Section {
+                    ForEach(exercises) { exercise in
+                        Button {
+                            exerciseToEdit = exercise
+                        } label: {
+                            HStack(spacing: 12) {
+                                Text(exercise.name)
+                                    .foregroundStyle(.primary)
+                                Spacer()
+                                Text(exercise.targetDisplay)
+                                    .foregroundStyle(.secondary)
+                                    .font(.subheadline.monospacedDigit())
+                                Image(systemName: "chevron.right")
+                                    .font(.caption2)
+                                    .foregroundStyle(.tertiary)
+                            }
                         }
                     }
-                }
-                .onMove { from, to in
-                    var exercises = sortedExercises
-                    exercises.move(fromOffsets: from, toOffset: to)
-                    for (index, exercise) in exercises.enumerated() {
-                        exercise.sortOrder = index
+                    .onMove { from, to in
+                        moveExercises(in: sectionName, from: from, to: to)
                     }
-                    try? modelContext.save()
+                } header: {
+                    if sectionName.isEmpty {
+                        Text("Exercises")
+                    } else {
+                        Text(sectionName)
+                    }
                 }
             }
 
+            // Add group button
+            Section {
+                Button {
+                    showAddGroup = true
+                } label: {
+                    Label("Add Group", systemImage: "folder.badge.plus")
+                }
+            }
+
+            // Stats
             if !completedSessions.isEmpty {
                 Section("Stats") {
                     LabeledContent("Total Sessions", value: "\(completedSessions.count)")
@@ -59,6 +86,7 @@ struct WorkoutPlanDetailView: View {
                 }
             }
 
+            // Recent history
             if !completedSessions.isEmpty {
                 Section("Recent Sessions") {
                     ForEach(completedSessions.prefix(5)) { session in
@@ -95,6 +123,38 @@ struct WorkoutPlanDetailView: View {
                 EditExerciseView(exercise: exercise)
             }
         }
+        .alert("New Group", isPresented: $showAddGroup) {
+            TextField("Group name", text: $newGroupName)
+            Button("Cancel", role: .cancel) { newGroupName = "" }
+            Button("Add") {
+                addGroup(newGroupName)
+                newGroupName = ""
+            }
+        } message: {
+            Text("Enter a name for the exercise group")
+        }
+    }
+
+    private func moveExercises(in sectionName: String, from: IndexSet, to: Int) {
+        guard var sectionExercises = sections.first(where: { $0.0 == sectionName })?.1 else { return }
+        sectionExercises.move(fromOffsets: from, toOffset: to)
+
+        // Recalculate sort orders across all sections
+        var order = 0
+        for (name, _) in sections {
+            let exercises = name == sectionName ? sectionExercises : sections.first(where: { $0.0 == name })!.1
+            for exercise in exercises {
+                exercise.sortOrder = order
+                order += 1
+            }
+        }
+        try? modelContext.save()
+    }
+
+    private func addGroup(_ name: String) {
+        // Group becomes available in the EditExerciseView section picker.
+        // Exercises are assigned to groups by editing them.
+        // To make the group visible immediately, we store it as a known section.
     }
 }
 
@@ -105,11 +165,32 @@ struct EditExerciseView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
 
+    private var availableSections: [String] {
+        guard let plan = exercise.plan else { return [""] }
+        let sections = Set(plan.exercises.map(\.section))
+        var result = sections.sorted()
+        if !result.contains("") { result.insert("", at: 0) }
+        return result
+    }
+
     var body: some View {
         Form {
             Section("Exercise") {
                 Text(exercise.name)
                     .font(.headline)
+            }
+
+            Section("Group") {
+                TextField("Group name (optional)", text: $exercise.section)
+                if !availableSections.filter({ !$0.isEmpty }).isEmpty {
+                    Picker("Existing groups", selection: $exercise.section) {
+                        Text("None").tag("")
+                        ForEach(availableSections.filter { !$0.isEmpty }, id: \.self) { section in
+                            Text(section).tag(section)
+                        }
+                    }
+                    .pickerStyle(.menu)
+                }
             }
 
             Section("Sets & Reps") {

--- a/OneTrack/Views/Workouts/WorkoutPlanListView.swift
+++ b/OneTrack/Views/Workouts/WorkoutPlanListView.swift
@@ -201,7 +201,7 @@ struct WorkoutPlanListView: View {
         let previous = findPreviousSession(for: session)
 
         for exercise in plan.exercises.sorted(by: { $0.sortOrder < $1.sortOrder }) {
-            let log = ExerciseLog(exerciseName: exercise.name, sortOrder: exercise.sortOrder, isIsometric: exercise.isIsometric)
+            let log = ExerciseLog(exerciseName: exercise.name, sortOrder: exercise.sortOrder, isIsometric: exercise.isIsometric, section: exercise.section)
             log.session = session
             modelContext.insert(log)
 

--- a/OneTrackTests/WorkoutPlanParserTests.swift
+++ b/OneTrackTests/WorkoutPlanParserTests.swift
@@ -206,4 +206,41 @@ struct WorkoutPlanParserTests {
         #expect(plans[0].rest == 90)
         #expect(plans[1].rest == 120)
     }
+
+    @Test func parseSections() throws {
+        let input = """
+        ---
+        name: Legs A
+
+        [Activation]
+        - Spanish Squat: 3x45s
+        - Spring Ankle: 3x30s
+
+        [Main Strength]
+        - Leg Press: 4x7
+        - Leg Extension: 3x11
+
+        [Rehab]
+        - TKE's: 3x20
+        """
+        let plans = try WorkoutPlanParser.parse(input)
+        #expect(plans.count == 1)
+        #expect(plans[0].exercises.count == 5)
+        #expect(plans[0].exercises[0].section == "Activation")
+        #expect(plans[0].exercises[1].section == "Activation")
+        #expect(plans[0].exercises[2].section == "Main Strength")
+        #expect(plans[0].exercises[3].section == "Main Strength")
+        #expect(plans[0].exercises[4].section == "Rehab")
+    }
+
+    @Test func parseNoSectionsHaveEmptySection() throws {
+        let input = """
+        ---
+        name: Simple
+
+        - Bench: 4x10
+        """
+        let plans = try WorkoutPlanParser.parse(input)
+        #expect(plans[0].exercises[0].section == "")
+    }
 }


### PR DESCRIPTION
## Summary
- Exercise groups/sections within workout plans (e.g. "Activation", "Main Strength", "Rehab")
- Exercises grouped by section in plan detail and active workout views
- Edit exercise: change group, sets, reps/seconds via sheet
- Reorder exercises within groups via drag
- Add exercise mid-workout
- Import parser supports `[Section Name]` syntax
- Isometric exercises show correct seconds display everywhere

## Test plan
- [x] 70 tests pass locally
- [x] CI passes
- [ ] Import plan with `[Section]` headers → verify groups display
- [ ] Edit exercise → change group → verify it moves
- [ ] Active workout shows section headers

Closes #22 #23 #24 #25 #27 #28