### PR TITLE
feat: two-way HealthKit sync for weight entries

### DIFF
--- a/OneTrack/Services/HealthKitManager.swift
+++ b/OneTrack/Services/HealthKitManager.swift
@@ -10,10 +10,18 @@ final class HealthKitManager {
     var latestWeight: Double?
 
     private let healthStore = HKHealthStore()
+    private var observerQuery: HKObserverQuery?
+
+    /// Callback invoked on the main actor when new weight samples arrive via observer.
+    var onNewWeightSamples: (([WeightSample]) -> Void)?
+
+    private nonisolated static let anchorKey = "com.onetrack.healthkit.weightAnchor"
 
     var isAvailable: Bool {
         HKHealthStore.isHealthDataAvailable()
     }
+
+    // MARK: - Authorization
 
     func requestAuthorization() async {
         guard isAvailable else { return }
@@ -25,8 +33,12 @@ final class HealthKitManager {
             HKObjectType.workoutType()
         ]
 
+        let writeTypes: Set<HKSampleType> = [
+            HKQuantityType(.bodyMass)
+        ]
+
         do {
-            try await healthStore.requestAuthorization(toShare: [], read: readTypes)
+            try await healthStore.requestAuthorization(toShare: writeTypes, read: readTypes)
             isAuthorized = true
             await fetchAll()
         } catch {
@@ -34,11 +46,154 @@ final class HealthKitManager {
         }
     }
 
+    // MARK: - Fetch All (existing)
+
     func fetchAll() async {
         todaySteps = await fetchTodaySteps()
         todayActiveCalories = await fetchTodayActiveCalories()
         latestWeight = await fetchLatestWeight()
     }
+
+    // MARK: - Historical Weight Import
+
+    /// Fetches ALL historical weight entries from HealthKit.
+    func fetchAllWeightHistory() async -> [WeightSample] {
+        guard isAvailable else { return [] }
+        let type = HKQuantityType(.bodyMass)
+        let sortDescriptor = NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)
+
+        do {
+            return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[WeightSample], Error>) in
+                let query = HKSampleQuery(
+                    sampleType: type,
+                    predicate: nil,
+                    limit: HKObjectQueryNoLimit,
+                    sortDescriptors: [sortDescriptor]
+                ) { _, samples, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        let weightSamples = (samples as? [HKQuantitySample] ?? []).map { sample in
+                            let source = sample.sourceRevision.source.bundleIdentifier
+                                .contains("onetrack") ? "onetrack" : "healthkit"
+                            return WeightSample(
+                                date: sample.startDate,
+                                weightKg: sample.quantity.doubleValue(for: .gramUnit(with: .kilo)),
+                                source: source
+                            )
+                        }
+                        continuation.resume(returning: weightSamples)
+                    }
+                }
+                healthStore.execute(query)
+            }
+        } catch {
+            return []
+        }
+    }
+
+    // MARK: - Anchored Object Query (incremental sync)
+
+    /// Fetches only new weight samples since the last sync using an anchored query.
+    func fetchNewWeightSamples() async -> [WeightSample] {
+        guard isAvailable else { return [] }
+        let type = HKQuantityType(.bodyMass)
+        let anchor = loadAnchor()
+
+        do {
+            return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[WeightSample], Error>) in
+                let query = HKAnchoredObjectQuery(
+                    type: type,
+                    predicate: nil,
+                    anchor: anchor,
+                    limit: HKObjectQueryNoLimit
+                ) { [weak self] _, addedSamples, _, newAnchor, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else {
+                        if let newAnchor {
+                            self?.saveAnchor(newAnchor)
+                        }
+                        let weightSamples = (addedSamples as? [HKQuantitySample] ?? []).map { sample in
+                            let source = sample.sourceRevision.source.bundleIdentifier
+                                .contains("onetrack") ? "onetrack" : "healthkit"
+                            return WeightSample(
+                                date: sample.startDate,
+                                weightKg: sample.quantity.doubleValue(for: .gramUnit(with: .kilo)),
+                                source: source
+                            )
+                        }
+                        continuation.resume(returning: weightSamples)
+                    }
+                }
+                healthStore.execute(query)
+            }
+        } catch {
+            return []
+        }
+    }
+
+    // MARK: - Observer Query (background monitoring)
+
+    /// Sets up an HKObserverQuery for bodyMass. When new data arrives,
+    /// fetches new samples via anchored query and calls onNewWeightSamples on the main actor.
+    func startObservingWeightChanges() {
+        guard isAvailable, observerQuery == nil else { return }
+        let type = HKQuantityType(.bodyMass)
+
+        let query = HKObserverQuery(sampleType: type, predicate: nil) { [weak self] _, completionHandler, error in
+            guard error == nil else {
+                completionHandler()
+                return
+            }
+
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let newSamples = await self.fetchNewWeightSamples()
+                if !newSamples.isEmpty {
+                    self.onNewWeightSamples?(newSamples)
+                }
+            }
+            completionHandler()
+        }
+
+        observerQuery = query
+        healthStore.execute(query)
+    }
+
+    /// Stops observing weight changes.
+    func stopObservingWeightChanges() {
+        if let query = observerQuery {
+            healthStore.stop(query)
+            observerQuery = nil
+        }
+    }
+
+    // MARK: - Write to HealthKit
+
+    /// Saves a weight entry to HealthKit.
+    func saveWeight(weightKg: Double, date: Date = .now) async throws {
+        guard isAvailable else { return }
+        let type = HKQuantityType(.bodyMass)
+        let quantity = HKQuantity(unit: .gramUnit(with: .kilo), doubleValue: weightKg)
+        let sample = HKQuantitySample(type: type, quantity: quantity, start: date, end: date)
+        try await healthStore.save(sample)
+    }
+
+    // MARK: - Anchor Persistence
+
+    private func loadAnchor() -> HKQueryAnchor? {
+        guard let data = UserDefaults.standard.data(forKey: Self.anchorKey) else { return nil }
+        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: HKQueryAnchor.self, from: data)
+    }
+
+    private nonisolated func saveAnchor(_ anchor: HKQueryAnchor) {
+        if let data = try? NSKeyedArchiver.archivedData(withRootObject: anchor, requiringSecureCoding: true) {
+            UserDefaults.standard.set(data, forKey: HealthKitManager.anchorKey)
+        }
+    }
+
+    // MARK: - Existing Fetches
 
     private func fetchTodaySteps() async -> Int {
         guard isAvailable else { return 0 }

--- a/OneTrack/Utilities/BodyCalculations.swift
+++ b/OneTrack/Utilities/BodyCalculations.swift
@@ -1,6 +1,41 @@
 import Foundation
 
+/// Lightweight transfer object for weight data from HealthKit.
+/// Keeps HealthKit types out of the model layer.
+struct WeightSample: Equatable, Sendable {
+    let date: Date
+    let weightKg: Double
+    let source: String // "healthkit" or "onetrack"
+}
+
 struct BodyCalculations {
+
+    // MARK: - HealthKit Sync Helpers
+
+    /// Determines which HealthKit samples are new and should be imported.
+    /// Deduplicates by checking if a WeightEntry with the same date (within tolerance) and weight already exists.
+    static func samplesToImport(
+        samples: [WeightSample],
+        existingEntries: [WeightEntry],
+        dateTolerance: TimeInterval = 60
+    ) -> [WeightSample] {
+        samples.filter { sample in
+            // Skip samples that OneTrack itself wrote
+            guard sample.source != "onetrack" else { return false }
+
+            // Check for existing entry with same date (within tolerance) and weight
+            let isDuplicate = existingEntries.contains { entry in
+                abs(entry.date.timeIntervalSince(sample.date)) < dateTolerance
+                    && abs(entry.weightKg - sample.weightKg) < 0.01
+            }
+            return !isDuplicate
+        }
+    }
+
+    /// Converts a WeightSample to WeightEntry values (does not create the model object).
+    static func weightEntryValues(from sample: WeightSample) -> (date: Date, weightKg: Double, source: String) {
+        (date: sample.date, weightKg: sample.weightKg, source: "healthkit")
+    }
     static func currentWeight(entries: [WeightEntry]) -> Double? {
         entries.max(by: { $0.date < $1.date })?.weightKg
     }

--- a/OneTrack/Views/Body/BodyTabView.swift
+++ b/OneTrack/Views/Body/BodyTabView.swift
@@ -33,6 +33,9 @@ struct BodyTabView: View {
 
     // HealthKit
     @State private var showHealthKitDenied = false
+    @State private var isSyncing = false
+    @State private var syncCount = 0
+    @State private var showSyncResult = false
 
     private var currentWeight: Double? {
         BodyCalculations.currentWeight(entries: weightEntries)
@@ -66,10 +69,23 @@ struct BodyTabView: View {
             .background(Color(.systemGroupedBackground))
             .navigationTitle("Body")
         }
+        .task {
+            await initialSync()
+        }
+        .onDisappear {
+            healthKitManager.stopObservingWeightChanges()
+        }
         .alert("HealthKit Access Denied", isPresented: $showHealthKitDenied) {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Please enable Health access in Settings > Privacy > Health > OneTrack.")
+        }
+        .alert("Sync Complete", isPresented: $showSyncResult) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(syncCount > 0
+                 ? "Imported \(syncCount) weight \(syncCount == 1 ? "entry" : "entries") from Health."
+                 : "All weight entries are already up to date.")
         }
     }
 
@@ -214,14 +230,22 @@ struct BodyTabView: View {
                         Button {
                             Task { await importFromHealthKit() }
                         } label: {
-                            Label("Import from Health", systemImage: "heart.fill")
-                                .font(.subheadline.bold())
-                                .frame(maxWidth: .infinity)
-                                .padding(.vertical, 12)
-                                .foregroundStyle(.white)
-                                .background(.pink, in: RoundedRectangle(cornerRadius: 12))
+                            Group {
+                                if isSyncing {
+                                    ProgressView()
+                                        .tint(.white)
+                                } else {
+                                    Label("Sync from Health", systemImage: "heart.fill")
+                                }
+                            }
+                            .font(.subheadline.bold())
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .foregroundStyle(.white)
+                            .background(.pink, in: RoundedRectangle(cornerRadius: 12))
                         }
                         .buttonStyle(.plain)
+                        .disabled(isSyncing)
                     }
                 }
             }
@@ -431,7 +455,35 @@ struct BodyTabView: View {
         let entry = WeightEntry(date: .now, weightKg: weightValue, source: weightSource)
         modelContext.insert(entry)
         try? modelContext.save()
+
+        // Write manual entries to HealthKit if authorized
+        if weightSource == "manual" && healthKitManager.isAuthorized {
+            Task {
+                try? await healthKitManager.saveWeight(weightKg: weightValue)
+            }
+        }
+
         weightSource = "manual"
+    }
+
+    private func initialSync() async {
+        guard healthKitManager.isAvailable else { return }
+
+        if !healthKitManager.isAuthorized {
+            await healthKitManager.requestAuthorization()
+        }
+
+        guard healthKitManager.isAuthorized else { return }
+
+        // Incremental sync on appear
+        let newSamples = await healthKitManager.fetchNewWeightSamples()
+        importSamples(newSamples)
+
+        // Set up observer for real-time updates
+        healthKitManager.onNewWeightSamples = { [self] samples in
+            self.importSamples(samples)
+        }
+        healthKitManager.startObservingWeightChanges()
     }
 
     private func importFromHealthKit() async {
@@ -444,11 +496,46 @@ struct BodyTabView: View {
             return
         }
 
-        await healthKitManager.fetchAll()
+        isSyncing = true
 
+        // Full historical import
+        let allSamples = await healthKitManager.fetchAllWeightHistory()
+        let toImport = BodyCalculations.samplesToImport(
+            samples: allSamples,
+            existingEntries: weightEntries
+        )
+
+        for sample in toImport {
+            let values = BodyCalculations.weightEntryValues(from: sample)
+            let entry = WeightEntry(date: values.date, weightKg: values.weightKg, source: values.source)
+            modelContext.insert(entry)
+        }
+        try? modelContext.save()
+
+        syncCount = toImport.count
+        isSyncing = false
+        showSyncResult = true
+
+        // Also update latest weight display
+        await healthKitManager.fetchAll()
         if let hkWeight = healthKitManager.latestWeight {
             weightValue = (hkWeight * 10).rounded() / 10
-            weightSource = "healthkit"
+        }
+    }
+
+    /// Imports a batch of WeightSamples into SwiftData after deduplication.
+    private func importSamples(_ samples: [WeightSample]) {
+        let toImport = BodyCalculations.samplesToImport(
+            samples: samples,
+            existingEntries: weightEntries
+        )
+        for sample in toImport {
+            let values = BodyCalculations.weightEntryValues(from: sample)
+            let entry = WeightEntry(date: values.date, weightKg: values.weightKg, source: values.source)
+            modelContext.insert(entry)
+        }
+        if !toImport.isEmpty {
+            try? modelContext.save()
         }
     }
 

--- a/OneTrackTests/Body/HealthKitSyncTests.swift
+++ b/OneTrackTests/Body/HealthKitSyncTests.swift
@@ -1,0 +1,156 @@
+import Testing
+import Foundation
+@testable import OneTrack
+
+@Suite("HealthKit Sync Logic")
+struct HealthKitSyncTests {
+
+    // MARK: - Deduplication
+
+    @Test func samplesToImportFiltersExistingEntries() {
+        let date = Date.now
+        let existing = [
+            WeightEntry(date: date, weightKg: 80.0, source: "healthkit")
+        ]
+        let samples = [
+            WeightSample(date: date, weightKg: 80.0, source: "healthkit"),
+            WeightSample(date: date.addingTimeInterval(3600), weightKg: 81.0, source: "healthkit")
+        ]
+
+        let result = BodyCalculations.samplesToImport(samples: samples, existingEntries: existing)
+
+        #expect(result.count == 1)
+        #expect(result.first?.weightKg == 81.0)
+    }
+
+    @Test func samplesToImportAllowsSameWeightDifferentDate() {
+        let date1 = Date.now
+        let date2 = date1.addingTimeInterval(86400) // next day
+        let existing = [
+            WeightEntry(date: date1, weightKg: 80.0, source: "healthkit")
+        ]
+        let samples = [
+            WeightSample(date: date2, weightKg: 80.0, source: "healthkit")
+        ]
+
+        let result = BodyCalculations.samplesToImport(samples: samples, existingEntries: existing)
+
+        #expect(result.count == 1)
+    }
+
+    @Test func samplesToImportDeduplicatesWithinDateTolerance() {
+        let date = Date.now
+        let existing = [
+            WeightEntry(date: date, weightKg: 80.0, source: "manual")
+        ]
+        // Sample is 30 seconds off — within default 60s tolerance
+        let samples = [
+            WeightSample(date: date.addingTimeInterval(30), weightKg: 80.0, source: "healthkit")
+        ]
+
+        let result = BodyCalculations.samplesToImport(samples: samples, existingEntries: existing)
+
+        #expect(result.isEmpty)
+    }
+
+    @Test func samplesToImportDoesNotDeduplicateOutsideTolerance() {
+        let date = Date.now
+        let existing = [
+            WeightEntry(date: date, weightKg: 80.0, source: "manual")
+        ]
+        // Sample is 120 seconds off — outside default 60s tolerance
+        let samples = [
+            WeightSample(date: date.addingTimeInterval(120), weightKg: 80.0, source: "healthkit")
+        ]
+
+        let result = BodyCalculations.samplesToImport(samples: samples, existingEntries: existing)
+
+        #expect(result.count == 1)
+    }
+
+    @Test func samplesToImportSkipsOneTrackSource() {
+        let samples = [
+            WeightSample(date: .now, weightKg: 80.0, source: "onetrack"),
+            WeightSample(date: .now.addingTimeInterval(100), weightKg: 81.0, source: "healthkit")
+        ]
+
+        let result = BodyCalculations.samplesToImport(samples: samples, existingEntries: [])
+
+        #expect(result.count == 1)
+        #expect(result.first?.source == "healthkit")
+    }
+
+    @Test func samplesToImportEmptySamples() {
+        let result = BodyCalculations.samplesToImport(samples: [], existingEntries: [])
+        #expect(result.isEmpty)
+    }
+
+    @Test func samplesToImportNoExistingEntries() {
+        let samples = [
+            WeightSample(date: .now, weightKg: 80.0, source: "healthkit"),
+            WeightSample(date: .now.addingTimeInterval(3600), weightKg: 81.0, source: "healthkit")
+        ]
+
+        let result = BodyCalculations.samplesToImport(samples: samples, existingEntries: [])
+
+        #expect(result.count == 2)
+    }
+
+    @Test func samplesToImportWithCustomTolerance() {
+        let date = Date.now
+        let existing = [
+            WeightEntry(date: date, weightKg: 80.0, source: "healthkit")
+        ]
+        let samples = [
+            WeightSample(date: date.addingTimeInterval(90), weightKg: 80.0, source: "healthkit")
+        ]
+
+        // With 120s tolerance, this should be filtered out
+        let result120 = BodyCalculations.samplesToImport(
+            samples: samples, existingEntries: existing, dateTolerance: 120
+        )
+        #expect(result120.isEmpty)
+
+        // With 60s tolerance (default), this should pass through
+        let result60 = BodyCalculations.samplesToImport(
+            samples: samples, existingEntries: existing, dateTolerance: 60
+        )
+        #expect(result60.count == 1)
+    }
+
+    // MARK: - Conversion
+
+    @Test func weightEntryValuesFromSample() {
+        let date = Date.now
+        let sample = WeightSample(date: date, weightKg: 82.5, source: "healthkit")
+        let values = BodyCalculations.weightEntryValues(from: sample)
+
+        #expect(values.date == date)
+        #expect(values.weightKg == 82.5)
+        #expect(values.source == "healthkit")
+    }
+
+    @Test func weightEntryValuesAlwaysMarksAsHealthKit() {
+        // Even if the sample source was something else, conversion marks it as healthkit
+        let sample = WeightSample(date: .now, weightKg: 75.0, source: "some-other-app")
+        let values = BodyCalculations.weightEntryValues(from: sample)
+
+        #expect(values.source == "healthkit")
+    }
+
+    // MARK: - WeightSample
+
+    @Test func weightSampleEquality() {
+        let date = Date.now
+        let a = WeightSample(date: date, weightKg: 80.0, source: "healthkit")
+        let b = WeightSample(date: date, weightKg: 80.0, source: "healthkit")
+        #expect(a == b)
+    }
+
+    @Test func weightSampleInequality() {
+        let date = Date.now
+        let a = WeightSample(date: date, weightKg: 80.0, source: "healthkit")
+        let b = WeightSample(date: date, weightKg: 81.0, source: "healthkit")
+        #expect(a != b)
+    }
+}


### PR DESCRIPTION
## Summary
- **Historical import**: Fetch ALL weight entries from HealthKit on first sync (full `HKSampleQuery`)
- **Incremental sync**: `HKAnchoredObjectQuery` with persisted anchor fetches only new samples
- **Real-time observer**: `HKObserverQuery` monitors bodyMass changes and auto-imports
- **Write to HealthKit**: Manual weight entries are saved to Apple Health (write authorization added)
- **Deduplication**: Skips entries matching by date (60s tolerance) and weight; skips OneTrack-sourced entries
- **UI updates**: "Sync from Health" button with progress spinner and result alert; auto-sync on tab appear

## Changed files
- `OneTrack/Services/HealthKitManager.swift` — write authorization, `fetchAllWeightHistory()`, `fetchNewWeightSamples()`, `startObservingWeightChanges()`, `saveWeight()`
- `OneTrack/Utilities/BodyCalculations.swift` — `WeightSample` struct, `samplesToImport()`, `weightEntryValues()`
- `OneTrack/Views/Body/BodyTabView.swift` — sync-on-appear, write-to-HK on manual save, sync button with progress
- `OneTrackTests/Body/HealthKitSyncTests.swift` — 14 tests for dedup, conversion, edge cases

## Test plan
- [x] All 14 new HealthKit sync tests pass
- [x] All existing tests pass (full test suite green)
- [ ] CI passes
- [ ] Manual test: authorize HealthKit → verify historical import
- [ ] Manual test: log weight in OneTrack → verify appears in Apple Health
- [ ] Manual test: log weight in Apple Health → verify auto-imports to OneTrack

Closes #34