### PR TITLE
fix: workout plan management UX + add/remove sets

### DIFF
--- a/OneTrack/Models/WorkoutPlan.swift
+++ b/OneTrack/Models/WorkoutPlan.swift
@@ -11,6 +11,7 @@ final class WorkoutPlan {
     @Relationship(deleteRule: .cascade, inverse: \WorkoutSession.plan)
     var sessions: [WorkoutSession] = []
     var defaultRestSeconds: Int = 90
+    var knownGroups: [String] = []
     var createdAt: Date = Date()
 
     init(name: String, planDescription: String, sortOrder: Int, defaultRestSeconds: Int = 90, createdAt: Date = .now) {

--- a/OneTrack/Utilities/PlanManagement.swift
+++ b/OneTrack/Utilities/PlanManagement.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Testable utility functions for workout plan management operations.
+struct PlanManagement {
+
+    /// Reorders exercises within a section by applying an IndexSet move, then recalculates
+    /// sortOrder globally across all sections to maintain consistent ordering.
+    ///
+    /// - Parameters:
+    ///   - exercises: All exercises in the plan (will be mutated in place via reference)
+    ///   - sectionName: The section in which the move is occurring
+    ///   - from: Source indices (relative to the section)
+    ///   - to: Destination index (relative to the section)
+    static func reorderExercises(
+        allExercises: [Exercise],
+        inSection sectionName: String,
+        from: IndexSet,
+        to: Int
+    ) {
+        let sorted = allExercises.sorted { $0.sortOrder < $1.sortOrder }
+
+        // Build ordered sections
+        var sectionOrder: [String] = []
+        for exercise in sorted {
+            if !sectionOrder.contains(exercise.section) {
+                sectionOrder.append(exercise.section)
+            }
+        }
+
+        // Group by section preserving order
+        var grouped: [String: [Exercise]] = [:]
+        for exercise in sorted {
+            grouped[exercise.section, default: []].append(exercise)
+        }
+
+        // Apply the move in the target section
+        if var sectionExercises = grouped[sectionName] {
+            sectionExercises.move(fromOffsets: from, toOffset: to)
+            grouped[sectionName] = sectionExercises
+        }
+
+        // Recalculate sort orders globally
+        var order = 0
+        for section in sectionOrder {
+            for exercise in grouped[section] ?? [] {
+                exercise.sortOrder = order
+                order += 1
+            }
+        }
+    }
+
+    /// Moves an exercise to a different section, placing it at the end of the target section.
+    static func moveExerciseToSection(_ exercise: Exercise, newSection: String, allExercises: [Exercise]) {
+        exercise.section = newSection
+
+        // Recalculate sort orders: exercises keep their relative order within sections
+        let sorted = allExercises.sorted { $0.sortOrder < $1.sortOrder }
+        var sectionOrder: [String] = []
+        for ex in sorted {
+            if !sectionOrder.contains(ex.section) {
+                sectionOrder.append(ex.section)
+            }
+        }
+
+        var order = 0
+        for section in sectionOrder {
+            let sectionExercises = sorted.filter { $0.section == section }
+            for ex in sectionExercises {
+                ex.sortOrder = order
+                order += 1
+            }
+        }
+    }
+
+    /// Deletes exercises at the given indices within a section, then recalculates sort order.
+    static func deleteExercises(
+        allExercises: [Exercise],
+        inSection sectionName: String,
+        at offsets: IndexSet
+    ) -> [Exercise] {
+        let sorted = allExercises.sorted { $0.sortOrder < $1.sortOrder }
+        let sectionExercises = sorted.filter { $0.section == sectionName }
+        let toDelete = offsets.map { sectionExercises[$0] }
+
+        // Recalculate sort orders for remaining exercises
+        let remaining = sorted.filter { !toDelete.contains($0) }
+        for (index, exercise) in remaining.enumerated() {
+            exercise.sortOrder = index
+        }
+
+        return toDelete
+    }
+
+    /// Reorders plans by applying an IndexSet move and recalculating sortOrder.
+    static func reorderPlans(_ plans: inout [WorkoutPlan], from: IndexSet, to: Int) {
+        plans.move(fromOffsets: from, toOffset: to)
+        for (index, plan) in plans.enumerated() {
+            plan.sortOrder = index
+        }
+    }
+
+    /// Deletes a set from an exercise log and renumbers remaining sets.
+    static func deleteSet(_ setLog: SetLog, from exerciseLog: ExerciseLog) {
+        let remaining = exerciseLog.sets
+            .filter { $0.id != setLog.id }
+            .sorted { $0.setNumber < $1.setNumber }
+        for (index, s) in remaining.enumerated() {
+            s.setNumber = index + 1
+        }
+    }
+}
+
+// Exercise needs Equatable conformance for contains() — @Model provides identity via id
+extension Exercise: Equatable {
+    static func == (lhs: Exercise, rhs: Exercise) -> Bool {
+        lhs.id == rhs.id
+    }
+}

--- a/OneTrack/Views/Workouts/ActiveWorkoutView.swift
+++ b/OneTrack/Views/Workouts/ActiveWorkoutView.swift
@@ -81,7 +81,8 @@ struct ActiveWorkoutView: View {
                                 onPRDetected: {
                                     triggerPRCelebration()
                                 },
-                                onAddSet: { addSet(to: log) }
+                                onAddSet: { addSet(to: log) },
+                                onDeleteSet: { setLog in deleteSet(setLog, from: log) }
                             )
                         }
                     }
@@ -319,6 +320,12 @@ struct ActiveWorkoutView: View {
         withAnimation { isResting = true }
     }
 
+    private func deleteSet(_ setLog: SetLog, from log: ExerciseLog) {
+        PlanManagement.deleteSet(setLog, from: log)
+        modelContext.delete(setLog)
+        try? modelContext.save()
+    }
+
     private func addSet(to log: ExerciseLog) {
         let sortedSets = log.sets.sorted { $0.setNumber < $1.setNumber }
         let lastSet = sortedSets.last
@@ -380,6 +387,7 @@ private struct ExerciseSectionView: View {
     let onSetCompleted: () -> Void
     let onPRDetected: () -> Void
     let onAddSet: () -> Void
+    let onDeleteSet: (SetLog) -> Void
 
     private var sortedSets: [SetLog] {
         log.sets.sorted { $0.setNumber < $1.setNumber }
@@ -458,6 +466,15 @@ private struct ExerciseSectionView: View {
                     onCompleted: onSetCompleted,
                     onPRDetected: onPRDetected
                 )
+                .contextMenu {
+                    if sortedSets.count > 1 {
+                        Button(role: .destructive) {
+                            onDeleteSet(setLog)
+                        } label: {
+                            Label("Delete Set", systemImage: "trash")
+                        }
+                    }
+                }
 
                 if setLog.setNumber < sortedSets.count {
                     Divider()

--- a/OneTrack/Views/Workouts/WorkoutPlanDetailView.swift
+++ b/OneTrack/Views/Workouts/WorkoutPlanDetailView.swift
@@ -4,9 +4,8 @@ import SwiftData
 struct WorkoutPlanDetailView: View {
     let plan: WorkoutPlan
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.editMode) private var editMode
     @State private var exerciseToEdit: Exercise?
-    @State private var showAddGroup = false
-    @State private var newGroupName = ""
 
     private var sortedExercises: [Exercise] {
         plan.exercises.sorted { $0.sortOrder < $1.sortOrder }
@@ -20,9 +19,14 @@ struct WorkoutPlanDetailView: View {
                 sectionOrder.append(exercise.section)
             }
         }
-        return sectionOrder.compactMap { section in
-            guard let exercises = grouped[section] else { return nil }
-            return (section, exercises)
+        // Include known empty groups
+        for group in plan.knownGroups {
+            if !sectionOrder.contains(group) {
+                sectionOrder.append(group)
+            }
+        }
+        return sectionOrder.map { section in
+            (section, grouped[section] ?? [])
         }
     }
 
@@ -32,28 +36,36 @@ struct WorkoutPlanDetailView: View {
 
     var body: some View {
         List {
-            // Exercise sections
             ForEach(sections, id: \.0) { sectionName, exercises in
                 Section {
-                    ForEach(exercises) { exercise in
-                        Button {
-                            exerciseToEdit = exercise
-                        } label: {
-                            HStack(spacing: 12) {
-                                Text(exercise.name)
-                                    .foregroundStyle(.primary)
-                                Spacer()
-                                Text(exercise.targetDisplay)
-                                    .foregroundStyle(.secondary)
-                                    .font(.subheadline.monospacedDigit())
-                                Image(systemName: "chevron.right")
-                                    .font(.caption2)
-                                    .foregroundStyle(.tertiary)
-                            }
+                    if exercises.isEmpty {
+                        Text("No exercises")
+                            .font(.caption)
+                            .foregroundStyle(.tertiary)
+                    } else {
+                        ForEach(exercises) { exercise in
+                            exerciseRow(exercise)
                         }
-                    }
-                    .onMove { from, to in
-                        moveExercises(in: sectionName, from: from, to: to)
+                        .onMove { from, to in
+                            PlanManagement.reorderExercises(
+                                allExercises: Array(plan.exercises),
+                                inSection: sectionName,
+                                from: from,
+                                to: to
+                            )
+                            try? modelContext.save()
+                        }
+                        .onDelete { offsets in
+                            let toDelete = PlanManagement.deleteExercises(
+                                allExercises: Array(plan.exercises),
+                                inSection: sectionName,
+                                at: offsets
+                            )
+                            for exercise in toDelete {
+                                modelContext.delete(exercise)
+                            }
+                            try? modelContext.save()
+                        }
                     }
                 } header: {
                     if sectionName.isEmpty {
@@ -64,13 +76,9 @@ struct WorkoutPlanDetailView: View {
                 }
             }
 
-            // Add group button
+            // Add group
             Section {
-                Button {
-                    showAddGroup = true
-                } label: {
-                    Label("Add Group", systemImage: "folder.badge.plus")
-                }
+                addGroupButton
             }
 
             // Stats
@@ -86,7 +94,7 @@ struct WorkoutPlanDetailView: View {
                 }
             }
 
-            // Recent history
+            // Recent sessions
             if !completedSessions.isEmpty {
                 Section("Recent Sessions") {
                     ForEach(completedSessions.prefix(5)) { session in
@@ -120,41 +128,60 @@ struct WorkoutPlanDetailView: View {
         }
         .sheet(item: $exerciseToEdit) { exercise in
             NavigationStack {
-                EditExerciseView(exercise: exercise)
+                EditExerciseView(exercise: exercise, knownGroups: plan.knownGroups)
             }
+        }
+    }
+
+    // MARK: - Exercise Row
+
+    private func exerciseRow(_ exercise: Exercise) -> some View {
+        Button {
+            exerciseToEdit = exercise
+        } label: {
+            HStack(spacing: 12) {
+                Text(exercise.name)
+                    .foregroundStyle(.primary)
+                Spacer()
+                Text(exercise.targetDisplay)
+                    .foregroundStyle(.secondary)
+                    .font(.subheadline.monospacedDigit())
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    // MARK: - Add Group
+
+    @State private var showAddGroup = false
+    @State private var newGroupName = ""
+
+    private var addGroupButton: some View {
+        Button {
+            showAddGroup = true
+        } label: {
+            Label("Add Group", systemImage: "folder.badge.plus")
         }
         .alert("New Group", isPresented: $showAddGroup) {
             TextField("Group name", text: $newGroupName)
             Button("Cancel", role: .cancel) { newGroupName = "" }
             Button("Add") {
-                addGroup(newGroupName)
+                let trimmed = newGroupName.trimmingCharacters(in: .whitespaces)
+                if !trimmed.isEmpty {
+                    var groups = plan.knownGroups
+                    if !groups.contains(trimmed) {
+                        groups.append(trimmed)
+                        plan.knownGroups = groups
+                        try? modelContext.save()
+                    }
+                }
                 newGroupName = ""
             }
         } message: {
             Text("Enter a name for the exercise group")
         }
-    }
-
-    private func moveExercises(in sectionName: String, from: IndexSet, to: Int) {
-        guard var sectionExercises = sections.first(where: { $0.0 == sectionName })?.1 else { return }
-        sectionExercises.move(fromOffsets: from, toOffset: to)
-
-        // Recalculate sort orders across all sections
-        var order = 0
-        for (name, _) in sections {
-            let exercises = name == sectionName ? sectionExercises : sections.first(where: { $0.0 == name })!.1
-            for exercise in exercises {
-                exercise.sortOrder = order
-                order += 1
-            }
-        }
-        try? modelContext.save()
-    }
-
-    private func addGroup(_ name: String) {
-        // Group becomes available in the EditExerciseView section picker.
-        // Exercises are assigned to groups by editing them.
-        // To make the group visible immediately, we store it as a known section.
     }
 }
 
@@ -164,13 +191,13 @@ struct EditExerciseView: View {
     @Bindable var exercise: Exercise
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
+    let knownGroups: [String]
 
     private var availableSections: [String] {
-        guard let plan = exercise.plan else { return [""] }
-        let sections = Set(plan.exercises.map(\.section))
-        var result = sections.sorted()
-        if !result.contains("") { result.insert("", at: 0) }
-        return result
+        guard let plan = exercise.plan else { return knownGroups }
+        let usedSections = Set(plan.exercises.map(\.section))
+        let all = Set(knownGroups).union(usedSections)
+        return all.sorted()
     }
 
     var body: some View {

--- a/OneTrack/Views/Workouts/WorkoutPlanListView.swift
+++ b/OneTrack/Views/Workouts/WorkoutPlanListView.swift
@@ -11,6 +11,8 @@ struct WorkoutPlanListView: View {
     @State private var activeSession: WorkoutSession?
     @State private var previousSessionForActive: WorkoutSession?
     @State private var planToEdit: WorkoutPlan?
+    @State private var planToDelete: WorkoutPlan?
+    @State private var showDeleteConfirmation = false
 
     var body: some View {
         Group {
@@ -29,6 +31,18 @@ struct WorkoutPlanListView: View {
             NavigationStack {
                 CreatePlanView(editingPlan: plan)
             }
+        }
+        .alert("Delete Workout?", isPresented: $showDeleteConfirmation) {
+            Button("Cancel", role: .cancel) { planToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let plan = planToDelete {
+                    modelContext.delete(plan)
+                    try? modelContext.save()
+                }
+                planToDelete = nil
+            }
+        } message: {
+            Text("This will permanently delete \"\(planToDelete?.name ?? "")\" and all its exercises. This cannot be undone.")
         }
     }
 
@@ -64,21 +78,35 @@ struct WorkoutPlanListView: View {
     // MARK: - Plan List
 
     private var planList: some View {
-        ScrollView {
-            VStack(spacing: 12) {
-                // Resume banner
-                if let incompleteSession = incompleteSessions.first {
+        List {
+            // Resume banner
+            if let incompleteSession = incompleteSessions.first {
+                Section {
                     resumeBanner(incompleteSession)
                 }
+                .listRowInsets(EdgeInsets())
+                .listRowBackground(Color.clear)
+            }
 
-                // Plans
+            // Plans (reorderable)
+            Section {
                 ForEach(plans) { plan in
                     planRow(plan)
                 }
+                .onMove { from, to in
+                    var mutablePlans = Array(plans)
+                    PlanManagement.reorderPlans(&mutablePlans, from: from, to: to)
+                    try? modelContext.save()
+                }
+                .onDelete { offsets in
+                    if let index = offsets.first {
+                        planToDelete = plans[index]
+                        showDeleteConfirmation = true
+                    }
+                }
             }
-            .padding(.horizontal)
-            .padding(.top, 8)
         }
+        .listStyle(.insetGrouped)
     }
 
     // MARK: - Resume Banner
@@ -116,7 +144,7 @@ struct WorkoutPlanListView: View {
                     .foregroundStyle(.tertiary)
             }
             .padding(14)
-            .background(.background, in: RoundedRectangle(cornerRadius: 14))
+            .background(.orange.opacity(0.04), in: RoundedRectangle(cornerRadius: 14))
             .overlay(
                 RoundedRectangle(cornerRadius: 14)
                     .stroke(.orange.opacity(0.3), lineWidth: 1)
@@ -137,7 +165,6 @@ struct WorkoutPlanListView: View {
             .first
 
         return HStack(spacing: 14) {
-            // Plan info (tappable for detail)
             NavigationLink {
                 WorkoutPlanDetailView(plan: plan)
             } label: {
@@ -161,7 +188,6 @@ struct WorkoutPlanListView: View {
                 }
             }
 
-            // Start button
             Button {
                 startWorkout(plan: plan)
             } label: {
@@ -174,21 +200,19 @@ struct WorkoutPlanListView: View {
             }
             .buttonStyle(.plain)
         }
-        .padding(14)
-        .background(.background, in: RoundedRectangle(cornerRadius: 14))
-        .shadow(color: .black.opacity(0.04), radius: 4, y: 2)
-        .contextMenu {
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                planToDelete = plan
+                showDeleteConfirmation = true
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
             Button {
                 planToEdit = plan
             } label: {
                 Label("Edit", systemImage: "pencil")
             }
-            Button(role: .destructive) {
-                modelContext.delete(plan)
-                try? modelContext.save()
-            } label: {
-                Label("Delete", systemImage: "trash")
-            }
+            .tint(.blue)
         }
     }
 

--- a/OneTrackTests/Workouts/PlanManagementTests.swift
+++ b/OneTrackTests/Workouts/PlanManagementTests.swift
@@ -1,0 +1,180 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import OneTrack
+
+@Suite("Plan Management")
+@MainActor
+struct PlanManagementTests {
+
+    // MARK: - Exercise Reorder
+
+    @Test func reorderExercisesWithinSection() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let plan = WorkoutPlan(name: "Test", planDescription: "", sortOrder: 0)
+        context.insert(plan)
+
+        let ex1 = Exercise(name: "Bench", targetSets: 3, targetReps: 10, sortOrder: 0)
+        let ex2 = Exercise(name: "Squat", targetSets: 3, targetReps: 10, sortOrder: 1)
+        let ex3 = Exercise(name: "Deadlift", targetSets: 3, targetReps: 10, sortOrder: 2)
+        for ex in [ex1, ex2, ex3] {
+            ex.plan = plan
+            context.insert(ex)
+        }
+        try context.save()
+
+        // Move Deadlift (index 2) to position 0
+        PlanManagement.reorderExercises(
+            allExercises: plan.exercises,
+            inSection: "",
+            from: IndexSet(integer: 2),
+            to: 0
+        )
+
+        let sorted = plan.exercises.sorted { $0.sortOrder < $1.sortOrder }
+        #expect(sorted[0].name == "Deadlift")
+        #expect(sorted[1].name == "Bench")
+        #expect(sorted[2].name == "Squat")
+    }
+
+    @Test func reorderExercisesPreservesOtherSections() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let plan = WorkoutPlan(name: "Test", planDescription: "", sortOrder: 0)
+        context.insert(plan)
+
+        let ex1 = Exercise(name: "Bench", targetSets: 3, targetReps: 10, sortOrder: 0, section: "Push")
+        let ex2 = Exercise(name: "OHP", targetSets: 3, targetReps: 10, sortOrder: 1, section: "Push")
+        let ex3 = Exercise(name: "Squat", targetSets: 3, targetReps: 10, sortOrder: 2, section: "Legs")
+        for ex in [ex1, ex2, ex3] {
+            ex.plan = plan
+            context.insert(ex)
+        }
+        try context.save()
+
+        // Move OHP (index 1 in "Push") to position 0
+        PlanManagement.reorderExercises(
+            allExercises: plan.exercises,
+            inSection: "Push",
+            from: IndexSet(integer: 1),
+            to: 0
+        )
+
+        let sorted = plan.exercises.sorted { $0.sortOrder < $1.sortOrder }
+        #expect(sorted[0].name == "OHP")
+        #expect(sorted[1].name == "Bench")
+        #expect(sorted[2].name == "Squat")
+        #expect(sorted[2].section == "Legs")
+    }
+
+    // MARK: - Move Exercise to Section
+
+    @Test func moveExerciseToSection() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let plan = WorkoutPlan(name: "Test", planDescription: "", sortOrder: 0)
+        context.insert(plan)
+
+        let ex1 = Exercise(name: "Bench", targetSets: 3, targetReps: 10, sortOrder: 0, section: "Push")
+        let ex2 = Exercise(name: "Squat", targetSets: 3, targetReps: 10, sortOrder: 1, section: "Push")
+        for ex in [ex1, ex2] {
+            ex.plan = plan
+            context.insert(ex)
+        }
+        try context.save()
+
+        PlanManagement.moveExerciseToSection(ex2, newSection: "Legs", allExercises: plan.exercises)
+
+        #expect(ex2.section == "Legs")
+    }
+
+    // MARK: - Delete Exercises
+
+    @Test func deleteExerciseRecalculatesSortOrder() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let plan = WorkoutPlan(name: "Test", planDescription: "", sortOrder: 0)
+        context.insert(plan)
+
+        let ex1 = Exercise(name: "A", targetSets: 3, targetReps: 10, sortOrder: 0)
+        let ex2 = Exercise(name: "B", targetSets: 3, targetReps: 10, sortOrder: 1)
+        let ex3 = Exercise(name: "C", targetSets: 3, targetReps: 10, sortOrder: 2)
+        for ex in [ex1, ex2, ex3] {
+            ex.plan = plan
+            context.insert(ex)
+        }
+        try context.save()
+
+        let toDelete = PlanManagement.deleteExercises(
+            allExercises: plan.exercises,
+            inSection: "",
+            at: IndexSet(integer: 1) // Delete "B"
+        )
+
+        #expect(toDelete.count == 1)
+        #expect(toDelete[0].name == "B")
+
+        let remaining = plan.exercises.filter { !toDelete.contains($0) }
+            .sorted { $0.sortOrder < $1.sortOrder }
+        #expect(remaining[0].sortOrder == 0)
+        #expect(remaining[1].sortOrder == 1)
+    }
+
+    // MARK: - Plan Reorder
+
+    @Test func reorderPlans() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let p1 = WorkoutPlan(name: "Push", planDescription: "", sortOrder: 0)
+        let p2 = WorkoutPlan(name: "Pull", planDescription: "", sortOrder: 1)
+        let p3 = WorkoutPlan(name: "Legs", planDescription: "", sortOrder: 2)
+        for p in [p1, p2, p3] { context.insert(p) }
+        try context.save()
+
+        var plans = [p1, p2, p3]
+        PlanManagement.reorderPlans(&plans, from: IndexSet(integer: 2), to: 0)
+
+        #expect(plans[0].name == "Legs")
+        #expect(plans[0].sortOrder == 0)
+        #expect(plans[1].name == "Push")
+        #expect(plans[1].sortOrder == 1)
+        #expect(plans[2].name == "Pull")
+        #expect(plans[2].sortOrder == 2)
+    }
+
+    // MARK: - Set Deletion
+
+    @Test func deleteSetRenumbersRemaining() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let log = ExerciseLog(exerciseName: "Bench", sortOrder: 0)
+        context.insert(log)
+
+        let s1 = SetLog(setNumber: 1, reps: 10, weightKg: 80)
+        let s2 = SetLog(setNumber: 2, reps: 8, weightKg: 85)
+        let s3 = SetLog(setNumber: 3, reps: 6, weightKg: 90)
+        for s in [s1, s2, s3] {
+            s.exerciseLog = log
+            context.insert(s)
+        }
+        try context.save()
+
+        PlanManagement.deleteSet(s2, from: log)
+
+        let remaining = log.sets
+            .filter { $0.id != s2.id }
+            .sorted { $0.setNumber < $1.setNumber }
+        #expect(remaining.count == 2)
+        #expect(remaining[0].setNumber == 1)
+        #expect(remaining[0].reps == 10)
+        #expect(remaining[1].setNumber == 2)
+        #expect(remaining[1].reps == 6)
+    }
+}


### PR DESCRIPTION
## Summary

### Issue #41 — Workout Plan Management UX (7 fixes)
1. **moveExercises broken** — Extracted to `PlanManagement.reorderExercises()`, operates on model references directly instead of local copies
2. **addGroup empty** — Groups stored in `WorkoutPlan.knownGroups`, appear immediately even when empty
3. **No cross-group drag** — Edit exercise sheet allows changing group via picker or text field
4. **No swipe-to-delete exercises** — Added `.onDelete` modifier on exercise ForEach
5. **EditButton non-functional** — Wired `@Environment(\.editMode)`, drag handles and delete buttons work
6. **Plans can't be reordered** — Switched from ScrollView+VStack to List with `.onMove`, persists sortOrder
7. **No delete confirmation** — Alert with descriptive message before deleting a plan

### Issue #6 — Add/Remove Sets During Workout
- **Add set** button already existed from previous PR
- **Delete set** via context menu (long-press a set row)
- `PlanManagement.deleteSet()` renumbers remaining sets
- Minimum 1 set enforced (can't delete the last set)

## New Files
- `OneTrack/Utilities/PlanManagement.swift` — Testable utility functions for reorder, move, delete
- `OneTrackTests/Workouts/PlanManagementTests.swift` — 6 regression tests

## Test plan
- [x] 129 tests pass locally (0 failures)
- [ ] CI passes
- [ ] Drag exercises to reorder in plan detail
- [ ] Add group → verify it appears as empty section
- [ ] Delete exercise via swipe in edit mode
- [ ] Reorder plans via drag in list
- [ ] Delete plan → confirm alert appears
- [ ] Long-press set during workout → Delete Set

Closes #41
Closes #6