### PR TITLE
feat: activity tab — steps, calories, weekly charts from HealthKit

### DIFF
--- a/OneTrack/Services/HealthKitManager.swift
+++ b/OneTrack/Services/HealthKitManager.swift
@@ -193,6 +193,82 @@ final class HealthKitManager {
         }
     }
 
+    // MARK: - Weekly Activity Data
+
+    /// Fetches daily step counts for the last 7 days.
+    func fetchWeeklySteps() async -> [(date: Date, steps: Int)] {
+        guard isAvailable else { return emptyWeekData(stepDefault: 0) }
+        return await fetchDailyStatistics(
+            type: HKQuantityType(.stepCount),
+            unit: .count(),
+            days: 7
+        ).map { (date: $0.date, steps: Int($0.value)) }
+    }
+
+    /// Fetches daily active calories for the last 7 days.
+    func fetchWeeklyCalories() async -> [(date: Date, calories: Double)] {
+        guard isAvailable else { return emptyWeekData(calorieDefault: 0) }
+        return await fetchDailyStatistics(
+            type: HKQuantityType(.activeEnergyBurned),
+            unit: .kilocalorie(),
+            days: 7
+        ).map { (date: $0.date, calories: $0.value) }
+    }
+
+    private func fetchDailyStatistics(type: HKQuantityType, unit: HKUnit, days: Int) async -> [(date: Date, value: Double)] {
+        let calendar = Calendar.current
+        let endDate = Date.now
+        let startDate = calendar.date(byAdding: .day, value: -(days - 1), to: calendar.startOfDay(for: endDate))!
+
+        do {
+            return try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<[(date: Date, value: Double)], Error>) in
+                let query = HKStatisticsCollectionQuery(
+                    quantityType: type,
+                    quantitySamplePredicate: nil,
+                    options: .cumulativeSum,
+                    anchorDate: startDate,
+                    intervalComponents: DateComponents(day: 1)
+                )
+                query.initialResultsHandler = { _, collection, error in
+                    if let error {
+                        continuation.resume(throwing: error)
+                        return
+                    }
+                    var results: [(date: Date, value: Double)] = []
+                    collection?.enumerateStatistics(from: startDate, to: endDate) { statistics, _ in
+                        let sum = statistics.sumQuantity()?.doubleValue(for: unit) ?? 0
+                        results.append((date: statistics.startDate, value: sum))
+                    }
+                    continuation.resume(returning: results)
+                }
+                healthStore.execute(query)
+            }
+        } catch {
+            return (0..<days).map { offset in
+                let day = calendar.date(byAdding: .day, value: offset, to: startDate)!
+                return (date: day, value: 0)
+            }
+        }
+    }
+
+    private func emptyWeekData(stepDefault: Int) -> [(date: Date, steps: Int)] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: .now)
+        return (0..<7).reversed().map { offset in
+            let day = calendar.date(byAdding: .day, value: -offset, to: today)!
+            return (date: day, steps: stepDefault)
+        }
+    }
+
+    private func emptyWeekData(calorieDefault: Double) -> [(date: Date, calories: Double)] {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: .now)
+        return (0..<7).reversed().map { offset in
+            let day = calendar.date(byAdding: .day, value: -offset, to: today)!
+            return (date: day, calories: calorieDefault)
+        }
+    }
+
     // MARK: - Existing Fetches
 
     private func fetchTodaySteps() async -> Int {

--- a/OneTrack/Utilities/ActivityCalculations.swift
+++ b/OneTrack/Utilities/ActivityCalculations.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct ActivityCalculations {
+
+    /// Daily activity data point for charts.
+    struct DailyActivity: Equatable, Identifiable {
+        let date: Date
+        let steps: Int
+        let calories: Double
+        var id: Date { date }
+    }
+
+    /// Formats a step count with thousands separator.
+    static func formattedSteps(_ steps: Int) -> String {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.groupingSeparator = ","
+        return formatter.string(from: NSNumber(value: steps)) ?? "\(steps)"
+    }
+
+    /// Formats calories with no decimal places.
+    static func formattedCalories(_ calories: Double) -> String {
+        "\(Int(calories))"
+    }
+
+    /// Merges parallel arrays of daily steps and calories into DailyActivity points.
+    /// Both arrays must be the same length and aligned by index.
+    static func dailyActivity(
+        dailySteps: [(date: Date, steps: Int)],
+        dailyCalories: [(date: Date, calories: Double)]
+    ) -> [DailyActivity] {
+        zip(dailySteps, dailyCalories).map { steps, cals in
+            DailyActivity(date: steps.date, steps: steps.steps, calories: cals.calories)
+        }
+    }
+}

--- a/OneTrack/Views/Activity/ActivityTabView.swift
+++ b/OneTrack/Views/Activity/ActivityTabView.swift
@@ -1,26 +1,207 @@
 import SwiftUI
+import Charts
 
 struct ActivityTabView: View {
+    @State private var healthKit = HealthKitManager()
+    @State private var weeklySteps: [(date: Date, steps: Int)] = []
+    @State private var weeklyCalories: [(date: Date, calories: Double)] = []
+    @State private var hasLoaded = false
+
+    private var dailyActivity: [ActivityCalculations.DailyActivity] {
+        ActivityCalculations.dailyActivity(dailySteps: weeklySteps, dailyCalories: weeklyCalories)
+    }
+
     var body: some View {
         NavigationStack {
-            VStack(spacing: 16) {
-                Spacer()
-                Image(systemName: "flame.fill")
-                    .font(.system(size: 48))
-                    .foregroundStyle(.red.opacity(0.5))
-                Text("Activity")
-                    .font(.title3.bold())
-                Text("Coming in Phase 3")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                Text("Steps, active calories, and workouts from Apple Health")
-                    .font(.caption)
-                    .foregroundStyle(.tertiary)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
-                Spacer()
+            ScrollView {
+                VStack(spacing: 16) {
+                    if !healthKit.isAvailable {
+                        unavailableView
+                    } else if !healthKit.isAuthorized && hasLoaded {
+                        unauthorizedView
+                    } else {
+                        todayCards
+                        stepsChart
+                        caloriesChart
+                    }
+                }
+                .padding(.vertical)
             }
             .navigationTitle("Activity")
+            .task {
+                if !hasLoaded {
+                    await healthKit.requestAuthorization()
+                    await loadWeeklyData()
+                    hasLoaded = true
+                }
+            }
+            .refreshable {
+                await healthKit.fetchAll()
+                await loadWeeklyData()
+            }
         }
+    }
+
+    // MARK: - Today Cards
+
+    private var todayCards: some View {
+        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+            StatCard(
+                title: "Steps Today",
+                value: ActivityCalculations.formattedSteps(healthKit.todaySteps),
+                icon: "figure.walk",
+                color: .green
+            )
+            StatCard(
+                title: "Active Cal",
+                value: ActivityCalculations.formattedCalories(healthKit.todayActiveCalories),
+                icon: "flame.fill",
+                color: .orange
+            )
+        }
+        .padding(.horizontal)
+    }
+
+    // MARK: - Steps Chart
+
+    private var stepsChart: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Steps (7 Days)")
+                .font(.subheadline.bold())
+
+            if dailyActivity.isEmpty || dailyActivity.allSatisfy({ $0.steps == 0 }) {
+                chartPlaceholder("Step data will appear here")
+            } else {
+                Chart(dailyActivity) { day in
+                    BarMark(
+                        x: .value("Day", day.date, unit: .day),
+                        y: .value("Steps", day.steps)
+                    )
+                    .foregroundStyle(.green.gradient)
+                    .cornerRadius(4)
+                }
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { _ in
+                        AxisValueLabel(format: .dateTime.weekday(.narrow))
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { value in
+                        AxisGridLine()
+                        AxisValueLabel {
+                            if let v = value.as(Int.self) {
+                                Text(v >= 1000 ? String(format: "%.0fk", Double(v) / 1000) : "\(v)")
+                                    .font(.caption2)
+                            }
+                        }
+                    }
+                }
+                .frame(height: 150)
+            }
+        }
+        .cardStyle()
+        .padding(.horizontal)
+    }
+
+    // MARK: - Calories Chart
+
+    private var caloriesChart: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Active Calories (7 Days)")
+                .font(.subheadline.bold())
+
+            if dailyActivity.isEmpty || dailyActivity.allSatisfy({ $0.calories == 0 }) {
+                chartPlaceholder("Calorie data will appear here")
+            } else {
+                Chart(dailyActivity) { day in
+                    BarMark(
+                        x: .value("Day", day.date, unit: .day),
+                        y: .value("Calories", day.calories)
+                    )
+                    .foregroundStyle(.orange.gradient)
+                    .cornerRadius(4)
+                }
+                .chartXAxis {
+                    AxisMarks(values: .stride(by: .day)) { _ in
+                        AxisValueLabel(format: .dateTime.weekday(.narrow))
+                    }
+                }
+                .chartYAxis {
+                    AxisMarks(position: .leading) { value in
+                        AxisGridLine()
+                        AxisValueLabel()
+                    }
+                }
+                .frame(height: 150)
+            }
+        }
+        .cardStyle()
+        .padding(.horizontal)
+    }
+
+    // MARK: - States
+
+    private var unavailableView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "heart.slash")
+                .font(.system(size: 48))
+                .foregroundStyle(.tertiary)
+            Text("HealthKit Not Available")
+                .font(.title3.bold())
+            Text("Activity tracking requires an iPhone with Apple Health.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+            Spacer()
+        }
+    }
+
+    private var unauthorizedView: some View {
+        VStack(spacing: 16) {
+            Spacer()
+            Image(systemName: "lock.shield")
+                .font(.system(size: 48))
+                .foregroundStyle(.orange.opacity(0.5))
+            Text("Health Access Required")
+                .font(.title3.bold())
+            Text("OneTrack needs access to Apple Health to show your steps and calories.\n\nGo to Settings > Health > Data Access > OneTrack to enable.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 32)
+            Button {
+                Task { await healthKit.requestAuthorization() }
+            } label: {
+                Label("Request Access", systemImage: "heart.fill")
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                    .padding(.horizontal, 24)
+                    .padding(.vertical, 12)
+                    .background(.blue, in: Capsule())
+            }
+            Spacer()
+        }
+    }
+
+    private func chartPlaceholder(_ message: String) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "chart.bar.xaxis")
+                .font(.title3)
+                .foregroundStyle(.tertiary)
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 100)
+    }
+
+    // MARK: - Data Loading
+
+    private func loadWeeklyData() async {
+        weeklySteps = await healthKit.fetchWeeklySteps()
+        weeklyCalories = await healthKit.fetchWeeklyCalories()
     }
 }

--- a/OneTrackTests/Activity/ActivityCalculationsTests.swift
+++ b/OneTrackTests/Activity/ActivityCalculationsTests.swift
@@ -1,0 +1,62 @@
+import Testing
+import Foundation
+@testable import OneTrack
+
+@Suite("Activity Calculations")
+struct ActivityCalculationsTests {
+
+    @Test func formattedSteps_zero() {
+        #expect(ActivityCalculations.formattedSteps(0) == "0")
+    }
+
+    @Test func formattedSteps_hundreds() {
+        #expect(ActivityCalculations.formattedSteps(500) == "500")
+    }
+
+    @Test func formattedSteps_thousands() {
+        let result = ActivityCalculations.formattedSteps(8_432)
+        #expect(result == "8,432")
+    }
+
+    @Test func formattedSteps_tenThousands() {
+        let result = ActivityCalculations.formattedSteps(12_345)
+        #expect(result == "12,345")
+    }
+
+    @Test func formattedCalories_zero() {
+        #expect(ActivityCalculations.formattedCalories(0) == "0")
+    }
+
+    @Test func formattedCalories_truncatesDecimals() {
+        #expect(ActivityCalculations.formattedCalories(523.7) == "523")
+    }
+
+    @Test func dailyActivity_mergesArrays() {
+        let now = Date.now
+        let steps = [(date: now, steps: 1000)]
+        let cals = [(date: now, calories: 250.0)]
+        let result = ActivityCalculations.dailyActivity(dailySteps: steps, dailyCalories: cals)
+        #expect(result.count == 1)
+        #expect(result[0].steps == 1000)
+        #expect(result[0].calories == 250.0)
+    }
+
+    @Test func dailyActivity_emptyInput() {
+        let result = ActivityCalculations.dailyActivity(
+            dailySteps: [],
+            dailyCalories: []
+        )
+        #expect(result.isEmpty)
+    }
+
+    @Test func dailyActivity_multipleEntries() {
+        let d1 = Date.now
+        let d2 = Calendar.current.date(byAdding: .day, value: -1, to: d1)!
+        let steps = [(date: d1, steps: 5000), (date: d2, steps: 8000)]
+        let cals = [(date: d1, calories: 300.0), (date: d2, calories: 500.0)]
+        let result = ActivityCalculations.dailyActivity(dailySteps: steps, dailyCalories: cals)
+        #expect(result.count == 2)
+        #expect(result[0].steps == 5000)
+        #expect(result[1].steps == 8000)
+    }
+}


### PR DESCRIPTION
## Summary
Replaces the Activity tab placeholder with a functional HealthKit-powered activity view:
- **Steps today** — card showing daily step count from HealthKit
- **Active calories today** — card showing active energy burned
- **Steps chart (7 days)** — bar chart with daily steps for last week
- **Calories chart (7 days)** — bar chart with daily active calories for last week
- **Authorization handling** — graceful states for HealthKit unavailable (simulator) and access denied
- **Pull to refresh** — refreshes all HealthKit data

## New Files
- `OneTrack/Utilities/ActivityCalculations.swift` — pure formatting and data merge functions
- `OneTrackTests/Activity/ActivityCalculationsTests.swift` — 9 tests

## Changes
- `HealthKitManager.swift` — added `fetchWeeklySteps()`, `fetchWeeklyCalories()` using `HKStatisticsCollectionQuery`
- `ActivityTabView.swift` — full rewrite from placeholder

## Test Plan
- [x] 9 new tests: step formatting (0, hundreds, thousands, ten-thousands), calorie formatting, daily activity merge (empty, single, multiple)
- [x] All existing tests pass
- [x] Build succeeds
- [x] Empty/unauthorized states render correctly

Closes #3