### PR TITLE
fix: body tab UX — collapsible weights, measurement chart, smart defaults

### DIFF
--- a/OneTrack/Utilities/BodyCalculations.swift
+++ b/OneTrack/Utilities/BodyCalculations.swift
@@ -80,4 +80,42 @@ struct BodyCalculations {
         if change > 0 { return "red" }
         return "gray"
     }
+
+    // MARK: - Measurement Chart Data
+
+    struct MeasurementChartPoint: Identifiable {
+        let id = UUID()
+        let date: Date
+        let value: Double
+        let type: String
+    }
+
+    /// Extracts chart data from body measurements. Returns data points for each non-nil measurement type.
+    static func measurementChartData(
+        measurements: [BodyMeasurement],
+        limit: Int = 20
+    ) -> [MeasurementChartPoint] {
+        let sorted = measurements
+            .sorted { $0.date < $1.date }
+            .suffix(limit)
+
+        var points: [MeasurementChartPoint] = []
+        for m in sorted {
+            if let v = m.waistCm { points.append(MeasurementChartPoint(date: m.date, value: v, type: "Waist")) }
+            if let v = m.chestCm { points.append(MeasurementChartPoint(date: m.date, value: v, type: "Chest")) }
+            if let v = m.leftBicepCm { points.append(MeasurementChartPoint(date: m.date, value: v, type: "L. Bicep")) }
+            if let v = m.rightBicepCm { points.append(MeasurementChartPoint(date: m.date, value: v, type: "R. Bicep")) }
+        }
+        return points
+    }
+
+    /// Returns the latest values for each measurement type, used for smart defaults.
+    static func latestMeasurementValues(measurements: [BodyMeasurement]) -> (waist: Double?, chest: Double?, leftBicep: Double?, rightBicep: Double?) {
+        let sorted = measurements.sorted { $0.date > $1.date }
+        let waist = sorted.first(where: { $0.waistCm != nil })?.waistCm
+        let chest = sorted.first(where: { $0.chestCm != nil })?.chestCm
+        let leftBicep = sorted.first(where: { $0.leftBicepCm != nil })?.leftBicepCm
+        let rightBicep = sorted.first(where: { $0.rightBicepCm != nil })?.rightBicepCm
+        return (waist, chest, leftBicep, rightBicep)
+    }
 }

--- a/OneTrack/Views/Body/BodyTabView.swift
+++ b/OneTrack/Views/Body/BodyTabView.swift
@@ -13,11 +13,10 @@ struct BodyTabView: View {
 
     @State private var healthKitManager = HealthKitManager()
 
-    // Weight entry
+    // Weight entry — defaults loaded from last entry
     @State private var weightValue: Double = 75.0
-    @State private var weightSource: String = "manual"
 
-    // Measurement entry
+    // Measurement entry — defaults loaded from last entry
     @State private var waistValue: Double = 80.0
     @State private var chestValue: Double = 95.0
     @State private var leftBicepValue: Double = 32.0
@@ -33,9 +32,11 @@ struct BodyTabView: View {
 
     // HealthKit
     @State private var showHealthKitDenied = false
-    @State private var isSyncing = false
-    @State private var syncCount = 0
-    @State private var showSyncResult = false
+
+    // Collapsible sections
+    @State private var showRecentWeights = false
+    @State private var showRecentMeasurements = false
+    @State private var hasLoadedDefaults = false
 
     private var currentWeight: Double? {
         BodyCalculations.currentWeight(entries: weightEntries)
@@ -59,6 +60,7 @@ struct BodyTabView: View {
                 VStack(spacing: 20) {
                     statsGrid
                     weightChartSection
+                    measurementChartSection
                     logWeightSection
                     logMeasurementsSection
                     recentWeightsSection
@@ -71,6 +73,7 @@ struct BodyTabView: View {
         }
         .task {
             await initialSync()
+            loadDefaults()
         }
         .onDisappear {
             healthKitManager.stopObservingWeightChanges()
@@ -79,13 +82,6 @@ struct BodyTabView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Please enable Health access in Settings > Privacy > Health > OneTrack.")
-        }
-        .alert("Sync Complete", isPresented: $showSyncResult) {
-            Button("OK", role: .cancel) {}
-        } message: {
-            Text(syncCount > 0
-                 ? "Imported \(syncCount) weight \(syncCount == 1 ? "entry" : "entries") from Health."
-                 : "All weight entries are already up to date.")
         }
     }
 
@@ -99,21 +95,18 @@ struct BodyTabView: View {
                 icon: "scalemass.fill",
                 color: .blue
             )
-
             StatCard(
                 title: "Weekly Change",
                 value: BodyCalculations.weeklyChangeFormatted(weeklyChange),
                 icon: "arrow.up.arrow.down",
                 color: .purple
             )
-
             StatCard(
                 title: "Latest Waist",
                 value: latestWaist.map { String(format: "%.1f cm", $0) } ?? "--",
                 icon: "ruler.fill",
                 color: .orange
             )
-
             StatCard(
                 title: "Entries",
                 value: "\(entriesThisMonth)",
@@ -140,10 +133,7 @@ struct BodyTabView: View {
             .pickerStyle(.segmented)
             .padding(.horizontal)
 
-            let chartData = BodyCalculations.filteredEntries(
-                entries: weightEntries,
-                days: chartRange.days
-            )
+            let chartData = BodyCalculations.filteredEntries(entries: weightEntries, days: chartRange.days)
 
             if chartData.isEmpty {
                 VStack(spacing: 12) {
@@ -153,9 +143,6 @@ struct BodyTabView: View {
                     Text("No weight data yet")
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
-                    Text("Log your first weight entry below")
-                        .font(.caption)
-                        .foregroundStyle(.tertiary)
                 }
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 32)
@@ -192,7 +179,49 @@ struct BodyTabView: View {
         return minW...maxW
     }
 
-    // MARK: - Log Weight
+    // MARK: - Measurement Progress Chart
+
+    private var measurementChartSection: some View {
+        let chartData = BodyCalculations.measurementChartData(measurements: measurements)
+
+        return Group {
+            if !chartData.isEmpty {
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Measurement Trends")
+                        .font(.headline)
+                        .padding(.horizontal)
+
+                    Chart(chartData) { point in
+                        LineMark(
+                            x: .value("Date", point.date),
+                            y: .value("cm", point.value)
+                        )
+                        .foregroundStyle(by: .value("Type", point.type))
+                        .interpolationMethod(.catmullRom)
+
+                        PointMark(
+                            x: .value("Date", point.date),
+                            y: .value("cm", point.value)
+                        )
+                        .foregroundStyle(by: .value("Type", point.type))
+                        .symbolSize(20)
+                    }
+                    .chartForegroundStyleScale([
+                        "Waist": Color.blue,
+                        "Chest": Color.green,
+                        "L. Bicep": Color.orange,
+                        "R. Bicep": Color.purple
+                    ])
+                    .chartLegend(.visible)
+                    .frame(height: 180)
+                    .cardStyle()
+                    .padding(.horizontal)
+                }
+            }
+        }
+    }
+
+    // MARK: - Log Weight (sync button removed)
 
     private var logWeightSection: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -213,41 +242,17 @@ struct BodyTabView: View {
                     )
                 }
 
-                HStack(spacing: 12) {
-                    Button {
-                        saveWeight()
-                    } label: {
-                        Label("Save", systemImage: "checkmark.circle.fill")
-                            .font(.subheadline.bold())
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
-                            .foregroundStyle(.white)
-                            .background(.blue, in: RoundedRectangle(cornerRadius: 12))
-                    }
-                    .buttonStyle(.plain)
-
-                    if healthKitManager.isAvailable {
-                        Button {
-                            Task { await importFromHealthKit() }
-                        } label: {
-                            Group {
-                                if isSyncing {
-                                    ProgressView()
-                                        .tint(.white)
-                                } else {
-                                    Label("Sync from Health", systemImage: "heart.fill")
-                                }
-                            }
-                            .font(.subheadline.bold())
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
-                            .foregroundStyle(.white)
-                            .background(.pink, in: RoundedRectangle(cornerRadius: 12))
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(isSyncing)
-                    }
+                Button {
+                    saveWeight()
+                } label: {
+                    Label("Save", systemImage: "checkmark.circle.fill")
+                        .font(.subheadline.bold())
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .foregroundStyle(.white)
+                        .background(.blue, in: RoundedRectangle(cornerRadius: 12))
                 }
+                .buttonStyle(.plain)
             }
             .cardStyle()
             .padding(.horizontal)
@@ -312,40 +317,29 @@ struct BodyTabView: View {
         }
     }
 
-    // MARK: - Recent Weights
+    // MARK: - Recent Weights (collapsible)
 
     private var recentWeightsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Recent Weights")
-                .font(.headline)
-                .padding(.horizontal)
+            if !weightEntries.isEmpty {
+                DisclosureGroup(
+                    isExpanded: $showRecentWeights
+                ) {
+                    VStack(spacing: 0) {
+                        ForEach(Array(weightEntries.prefix(10).enumerated()), id: \.element.id) { index, entry in
+                            weightRow(entry)
 
-            if weightEntries.isEmpty {
-                VStack(spacing: 12) {
-                    Image(systemName: "scalemass")
-                        .font(.largeTitle)
-                        .foregroundStyle(.tertiary)
-                    Text("No weight entries yet")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 32)
-                .cardStyle()
-                .padding(.horizontal)
-            } else {
-                VStack(spacing: 0) {
-                    ForEach(Array(weightEntries.prefix(10).enumerated()), id: \.element.id) { index, entry in
-                        weightRow(entry)
-
-                        if index < min(weightEntries.count, 10) - 1 {
-                            Divider()
-                                .padding(.horizontal)
+                            if index < min(weightEntries.count, 10) - 1 {
+                                Divider()
+                                    .padding(.horizontal)
+                            }
                         }
                     }
+                } label: {
+                    Text("Recent Weights (\(weightEntries.count))")
+                        .font(.headline)
                 }
-                .background(.background, in: RoundedRectangle(cornerRadius: 16))
-                .shadow(color: .black.opacity(0.06), radius: 8, y: 4)
+                .cardStyle()
                 .padding(.horizontal)
             }
         }
@@ -376,40 +370,29 @@ struct BodyTabView: View {
         .padding(.vertical, 10)
     }
 
-    // MARK: - Recent Measurements
+    // MARK: - Recent Measurements (collapsible)
 
     private var recentMeasurementsSection: some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("Recent Measurements")
-                .font(.headline)
-                .padding(.horizontal)
+            if !measurements.isEmpty {
+                DisclosureGroup(
+                    isExpanded: $showRecentMeasurements
+                ) {
+                    VStack(spacing: 0) {
+                        ForEach(Array(measurements.prefix(10).enumerated()), id: \.element.id) { index, measurement in
+                            measurementRow(measurement)
 
-            if measurements.isEmpty {
-                VStack(spacing: 12) {
-                    Image(systemName: "ruler")
-                        .font(.largeTitle)
-                        .foregroundStyle(.tertiary)
-                    Text("No measurements yet")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 32)
-                .cardStyle()
-                .padding(.horizontal)
-            } else {
-                VStack(spacing: 0) {
-                    ForEach(Array(measurements.prefix(10).enumerated()), id: \.element.id) { index, measurement in
-                        measurementRow(measurement)
-
-                        if index < min(measurements.count, 10) - 1 {
-                            Divider()
-                                .padding(.horizontal)
+                            if index < min(measurements.count, 10) - 1 {
+                                Divider()
+                                    .padding(.horizontal)
+                            }
                         }
                     }
+                } label: {
+                    Text("Recent Measurements (\(measurements.count))")
+                        .font(.headline)
                 }
-                .background(.background, in: RoundedRectangle(cornerRadius: 16))
-                .shadow(color: .black.opacity(0.06), radius: 8, y: 4)
+                .cardStyle()
                 .padding(.horizontal)
             }
         }
@@ -451,19 +434,33 @@ struct BodyTabView: View {
 
     // MARK: - Actions
 
+    private func loadDefaults() {
+        guard !hasLoadedDefaults else { return }
+        hasLoadedDefaults = true
+
+        // Weight default from last entry
+        if let lastWeight = weightEntries.first?.weightKg {
+            weightValue = (lastWeight * 10).rounded() / 10
+        }
+
+        // Measurement defaults from last entries
+        let latest = BodyCalculations.latestMeasurementValues(measurements: measurements)
+        if let w = latest.waist { waistValue = w }
+        if let c = latest.chest { chestValue = c }
+        if let lb = latest.leftBicep { leftBicepValue = lb }
+        if let rb = latest.rightBicep { rightBicepValue = rb }
+    }
+
     private func saveWeight() {
-        let entry = WeightEntry(date: .now, weightKg: weightValue, source: weightSource)
+        let entry = WeightEntry(date: .now, weightKg: weightValue, source: "manual")
         modelContext.insert(entry)
         try? modelContext.save()
 
-        // Write manual entries to HealthKit if authorized
-        if weightSource == "manual" && healthKitManager.isAuthorized {
+        if healthKitManager.isAuthorized {
             Task {
                 try? await healthKitManager.saveWeight(weightKg: weightValue)
             }
         }
-
-        weightSource = "manual"
     }
 
     private func initialSync() async {
@@ -486,44 +483,6 @@ struct BodyTabView: View {
         healthKitManager.startObservingWeightChanges()
     }
 
-    private func importFromHealthKit() async {
-        if !healthKitManager.isAuthorized {
-            await healthKitManager.requestAuthorization()
-        }
-
-        guard healthKitManager.isAuthorized else {
-            showHealthKitDenied = true
-            return
-        }
-
-        isSyncing = true
-
-        // Full historical import
-        let allSamples = await healthKitManager.fetchAllWeightHistory()
-        let toImport = BodyCalculations.samplesToImport(
-            samples: allSamples,
-            existingEntries: weightEntries
-        )
-
-        for sample in toImport {
-            let values = BodyCalculations.weightEntryValues(from: sample)
-            let entry = WeightEntry(date: values.date, weightKg: values.weightKg, source: values.source)
-            modelContext.insert(entry)
-        }
-        try? modelContext.save()
-
-        syncCount = toImport.count
-        isSyncing = false
-        showSyncResult = true
-
-        // Also update latest weight display
-        await healthKitManager.fetchAll()
-        if let hkWeight = healthKitManager.latestWeight {
-            weightValue = (hkWeight * 10).rounded() / 10
-        }
-    }
-
-    /// Imports a batch of WeightSamples into SwiftData after deduplication.
     private func importSamples(_ samples: [WeightSample]) {
         let toImport = BodyCalculations.samplesToImport(
             samples: samples,
@@ -549,7 +508,6 @@ struct BodyTabView: View {
         modelContext.insert(m)
         try? modelContext.save()
 
-        // Reset toggles
         logWaist = false
         logChest = false
         logLeftBicep = false

--- a/OneTrackTests/Body/BodyMeasurementChartTests.swift
+++ b/OneTrackTests/Body/BodyMeasurementChartTests.swift
@@ -1,0 +1,117 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import OneTrack
+
+@Suite("Body Measurement Chart")
+@MainActor
+struct BodyMeasurementChartTests {
+
+    @Test func chartData_extractsAllTypes() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let m = BodyMeasurement(date: .now)
+        m.waistCm = 80
+        m.chestCm = 95
+        m.leftBicepCm = 32
+        m.rightBicepCm = 33
+        context.insert(m)
+        try context.save()
+
+        let data = BodyCalculations.measurementChartData(measurements: [m])
+        #expect(data.count == 4)
+        #expect(data.contains(where: { $0.type == "Waist" && $0.value == 80 }))
+        #expect(data.contains(where: { $0.type == "Chest" && $0.value == 95 }))
+        #expect(data.contains(where: { $0.type == "L. Bicep" && $0.value == 32 }))
+        #expect(data.contains(where: { $0.type == "R. Bicep" && $0.value == 33 }))
+    }
+
+    @Test func chartData_handlesPartialMeasurements() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let m = BodyMeasurement(date: .now)
+        m.waistCm = 80
+        // chest, biceps are nil
+        context.insert(m)
+        try context.save()
+
+        let data = BodyCalculations.measurementChartData(measurements: [m])
+        #expect(data.count == 1)
+        #expect(data[0].type == "Waist")
+    }
+
+    @Test func chartData_emptyMeasurements() {
+        let data = BodyCalculations.measurementChartData(measurements: [])
+        #expect(data.isEmpty)
+    }
+
+    @Test func chartData_respectsLimit() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        var measurements: [BodyMeasurement] = []
+        for i in 0..<25 {
+            let m = BodyMeasurement(date: Calendar.current.date(byAdding: .day, value: -i, to: .now)!)
+            m.waistCm = Double(80 + i)
+            context.insert(m)
+            measurements.append(m)
+        }
+        try context.save()
+
+        let data = BodyCalculations.measurementChartData(measurements: measurements, limit: 20)
+        // Only waist type, so max 20 data points
+        #expect(data.count == 20)
+    }
+
+    @Test func chartData_sortedByDate() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let older = BodyMeasurement(date: Calendar.current.date(byAdding: .day, value: -5, to: .now)!)
+        older.waistCm = 82
+        context.insert(older)
+
+        let newer = BodyMeasurement(date: .now)
+        newer.waistCm = 80
+        context.insert(newer)
+        try context.save()
+
+        let data = BodyCalculations.measurementChartData(measurements: [older, newer])
+        let waistPoints = data.filter { $0.type == "Waist" }
+        #expect(waistPoints.count == 2)
+        #expect(waistPoints[0].date < waistPoints[1].date)
+    }
+
+    // MARK: - Latest Measurement Values
+
+    @Test func latestMeasurementValues_findsMostRecent() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let older = BodyMeasurement(date: Calendar.current.date(byAdding: .day, value: -5, to: .now)!)
+        older.waistCm = 82
+        older.chestCm = 90
+        context.insert(older)
+
+        let newer = BodyMeasurement(date: .now)
+        newer.waistCm = 80
+        // No chest this time
+        context.insert(newer)
+        try context.save()
+
+        let latest = BodyCalculations.latestMeasurementValues(measurements: [older, newer])
+        #expect(latest.waist == 80)     // from newer
+        #expect(latest.chest == 90)     // from older (newest with chest)
+        #expect(latest.leftBicep == nil)
+    }
+
+    @Test func latestMeasurementValues_empty() {
+        let latest = BodyCalculations.latestMeasurementValues(measurements: [])
+        #expect(latest.waist == nil)
+        #expect(latest.chest == nil)
+        #expect(latest.leftBicep == nil)
+        #expect(latest.rightBicep == nil)
+    }
+}


### PR DESCRIPTION
## Summary

### 1. Collapsible recent weights
- Replaced always-visible weight list with `DisclosureGroup` collapsed by default
- Shows count in header: "Recent Weights (42)"

### 2. Measurement progress chart
- Multi-series line chart showing Waist (blue), Chest (green), L. Bicep (orange), R. Bicep (purple) over time
- Handles sparse data (only plots non-nil values)
- Chart data extraction in `BodyCalculations.measurementChartData()` (pure function, testable)

### 3. Removed "Sync from Health" button
- Auto-sync via HKObserverQuery already handles this (PR #38)
- Removed: `importFromHealthKit()`, `isSyncing`, `syncCount`, `showSyncResult`

### 4. Smart defaults from last entry
- Weight input defaults to last recorded weight (or 75.0 if none)
- Measurement inputs default to last recorded values per type
- `BodyCalculations.latestMeasurementValues()` finds most recent non-nil value for each field

## New Files
- `OneTrackTests/Body/BodyMeasurementChartTests.swift` — 7 tests

## Test plan
- [x] 193 tests pass locally (0 failures)
- [ ] CI passes
- [ ] Recent weights collapsed by default, expandable
- [ ] Measurement chart shows multiple series
- [ ] Weight defaults to last entry on reopen
- [ ] No "Sync from Health" button visible

Closes #51