### PR TITLE
fix: compact workout stepper layout, rename PREVIOUS to PREV, select-all on tap

### DIFF
--- a/OneTrack/Theme/TappableStepperInput.swift
+++ b/OneTrack/Theme/TappableStepperInput.swift
@@ -47,7 +47,14 @@ struct TappableStepperInput: View {
                     .focused($isEditing)
                     .opacity(isEditing ? 1 : 0)
                     .onChange(of: isEditing) {
-                        if !isEditing { commitEdit() }
+                        if isEditing {
+                            // Select all text so typing replaces the value immediately
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                                UIApplication.shared.sendAction(#selector(UIResponder.selectAll(_:)), to: nil, from: nil, for: nil)
+                            }
+                        } else {
+                            commitEdit()
+                        }
                     }
 
                 // Display text (hidden when editing)

--- a/OneTrack/Views/Workouts/ActiveWorkoutView.swift
+++ b/OneTrack/Views/Workouts/ActiveWorkoutView.swift
@@ -495,7 +495,7 @@ private struct ExerciseSectionView: View {
             HStack(spacing: 0) {
                 Text("SET")
                     .frame(width: 36)
-                Text("PREVIOUS")
+                Text("PREV")
                     .frame(maxWidth: .infinity)
                 Text(log.isIsometric ? "SEC" : "REPS")
                     .frame(width: 100)
@@ -832,7 +832,11 @@ private struct StepperInput<V: BinaryFloatingPoint>: View {
             ),
             step: Double(step),
             range: Double(range.lowerBound)...Double(range.upperBound),
-            decimals: decimals
+            decimals: decimals,
+            minWidth: 26,
+            buttonSize: 24,
+            buttonHeight: 28,
+            spacing: 1
         )
     }
 


### PR DESCRIPTION
## Summary

### 1. Compact StepperInput
Reduced spacing in the workout active view stepper:
- Button size: 28→24 width, 32→28 height
- Number min width: 32→26
- HStack spacing: 2→1
- SEC and KG columns now fit better on smaller screens

### 2. Column header rename
"PREVIOUS" → "PREV" — prevents text wrapping in narrow column

### 3. Select-all on tap
When tapping the stepper number to edit via keyboard, all text is selected so typing immediately replaces the value (uses `UIResponder.selectAll`). Applied globally via `TappableStepperInput` — benefits both workout and body steppers.

## Test plan
- [x] 193 tests pass locally
- [ ] CI passes
- [ ] Stepper buttons are more compact, columns fit on screen
- [ ] "PREV" shows instead of "PREVIOUS"
- [ ] Tap number → keyboard opens with all text selected

Closes #58