### PR TITLE
feat: export/import workout data as JSON backup

### DIFF
--- a/OneTrack/Utilities/WorkoutDataExporter.swift
+++ b/OneTrack/Utilities/WorkoutDataExporter.swift
@@ -1,0 +1,298 @@
+import Foundation
+import SwiftData
+
+// MARK: - Export/Import Data Model
+
+struct WorkoutBackup: Codable, Sendable {
+    let exportDate: Date
+    let appVersion: String
+    let plans: [PlanExport]
+    let sessions: [SessionExport]
+    let customExercises: [CustomExerciseExport]
+
+    struct PlanExport: Codable, Sendable {
+        let name: String
+        let description: String
+        let sortOrder: Int
+        let defaultRestSeconds: Int
+        let knownGroups: [String]
+        let exercises: [ExerciseExport]
+    }
+
+    struct ExerciseExport: Codable, Sendable {
+        let name: String
+        let targetSets: Int
+        let targetReps: Int
+        let isIsometric: Bool
+        let targetSeconds: Int
+        let section: String
+        let sortOrder: Int
+        let restSeconds: Int?
+    }
+
+    struct SessionExport: Codable, Sendable {
+        let planName: String
+        let date: Date
+        let durationSeconds: Int?
+        let isCompleted: Bool
+        let notes: String
+        let rpe: Int?
+        let exercises: [ExerciseLogExport]
+    }
+
+    struct ExerciseLogExport: Codable, Sendable {
+        let exerciseName: String
+        let isIsometric: Bool
+        let section: String
+        let sortOrder: Int
+        let notes: String
+        let sets: [SetLogExport]
+    }
+
+    struct SetLogExport: Codable, Sendable {
+        let setNumber: Int
+        let reps: Int
+        let seconds: Int
+        let weightKg: Double
+        let isCompleted: Bool
+        let isPersonalRecord: Bool
+        let setType: String
+    }
+
+    struct CustomExerciseExport: Codable, Sendable {
+        let name: String
+        let category: String
+        let defaultSets: Int
+        let defaultReps: Int
+        let isIsometric: Bool
+        let defaultSeconds: Int
+    }
+}
+
+// MARK: - Exporter
+
+struct WorkoutDataExporter {
+
+    static func export(
+        plans: [WorkoutPlan],
+        sessions: [WorkoutSession],
+        customExercises: [CustomExercise]
+    ) -> WorkoutBackup {
+        let planExports = plans
+            .sorted { $0.sortOrder < $1.sortOrder }
+            .map { plan in
+                WorkoutBackup.PlanExport(
+                    name: plan.name,
+                    description: plan.planDescription,
+                    sortOrder: plan.sortOrder,
+                    defaultRestSeconds: plan.defaultRestSeconds,
+                    knownGroups: plan.knownGroups,
+                    exercises: plan.exercises
+                        .sorted { $0.sortOrder < $1.sortOrder }
+                        .map { ex in
+                            WorkoutBackup.ExerciseExport(
+                                name: ex.name,
+                                targetSets: ex.targetSets,
+                                targetReps: ex.targetReps,
+                                isIsometric: ex.isIsometric,
+                                targetSeconds: ex.targetSeconds,
+                                section: ex.section,
+                                sortOrder: ex.sortOrder,
+                                restSeconds: ex.restSeconds
+                            )
+                        }
+                )
+            }
+
+        let sessionExports = sessions
+            .filter { $0.isCompleted }
+            .sorted { $0.date < $1.date }
+            .map { session in
+                WorkoutBackup.SessionExport(
+                    planName: session.plan?.name ?? "Unknown",
+                    date: session.date,
+                    durationSeconds: session.durationSeconds,
+                    isCompleted: session.isCompleted,
+                    notes: session.notes,
+                    rpe: session.rpe,
+                    exercises: session.exerciseLogs
+                        .sorted { $0.sortOrder < $1.sortOrder }
+                        .map { log in
+                            WorkoutBackup.ExerciseLogExport(
+                                exerciseName: log.exerciseName,
+                                isIsometric: log.isIsometric,
+                                section: log.section,
+                                sortOrder: log.sortOrder,
+                                notes: log.notes,
+                                sets: log.sets
+                                    .sorted { $0.setNumber < $1.setNumber }
+                                    .map { s in
+                                        WorkoutBackup.SetLogExport(
+                                            setNumber: s.setNumber,
+                                            reps: s.reps,
+                                            seconds: s.seconds,
+                                            weightKg: s.weightKg,
+                                            isCompleted: s.isCompleted,
+                                            isPersonalRecord: s.isPersonalRecord,
+                                            setType: s.setTypeRaw
+                                        )
+                                    }
+                            )
+                        }
+                )
+            }
+
+        let customExerciseExports = customExercises.map { ce in
+            WorkoutBackup.CustomExerciseExport(
+                name: ce.name,
+                category: ce.category,
+                defaultSets: ce.defaultSets,
+                defaultReps: ce.defaultReps,
+                isIsometric: ce.isIsometric,
+                defaultSeconds: ce.defaultSeconds
+            )
+        }
+
+        return WorkoutBackup(
+            exportDate: .now,
+            appVersion: "1.0",
+            plans: planExports,
+            sessions: sessionExports,
+            customExercises: customExerciseExports
+        )
+    }
+
+    static func exportJSON(backup: WorkoutBackup) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(backup)
+    }
+
+    static func importJSON(data: Data) throws -> WorkoutBackup {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(WorkoutBackup.self, from: data)
+    }
+
+    enum ImportMode {
+        case replace
+        case merge
+    }
+
+    static func restore(backup: WorkoutBackup, modelContext: ModelContext, mode: ImportMode) throws {
+        if mode == .replace {
+            try deleteAllData(modelContext: modelContext)
+        }
+
+        let existingPlanNames = mode == .merge ? Set(fetchExistingPlanNames(modelContext: modelContext)) : []
+        let existingCustomNames = mode == .merge ? Set(fetchExistingCustomExerciseNames(modelContext: modelContext)) : []
+
+        // Restore plans
+        for (index, planExport) in backup.plans.enumerated() {
+            if mode == .merge && existingPlanNames.contains(planExport.name) {
+                continue
+            }
+
+            let plan = WorkoutPlan(
+                name: planExport.name,
+                planDescription: planExport.description,
+                sortOrder: mode == .merge ? 1000 + index : planExport.sortOrder,
+                defaultRestSeconds: planExport.defaultRestSeconds
+            )
+            plan.knownGroups = planExport.knownGroups
+            modelContext.insert(plan)
+
+            for exExport in planExport.exercises {
+                let exercise = Exercise(
+                    name: exExport.name,
+                    targetSets: exExport.targetSets,
+                    targetReps: exExport.targetReps,
+                    sortOrder: exExport.sortOrder,
+                    isIsometric: exExport.isIsometric,
+                    targetSeconds: exExport.targetSeconds,
+                    restSeconds: exExport.restSeconds,
+                    section: exExport.section
+                )
+                exercise.plan = plan
+                modelContext.insert(exercise)
+            }
+
+            // Restore sessions linked to this plan
+            let planSessions = backup.sessions.filter { $0.planName == planExport.name }
+            for sessionExport in planSessions {
+                let session = WorkoutSession(date: sessionExport.date, plan: plan)
+                session.durationSeconds = sessionExport.durationSeconds
+                session.isCompleted = sessionExport.isCompleted
+                session.notes = sessionExport.notes
+                session.rpe = sessionExport.rpe
+                modelContext.insert(session)
+
+                for logExport in sessionExport.exercises {
+                    let log = ExerciseLog(
+                        exerciseName: logExport.exerciseName,
+                        sortOrder: logExport.sortOrder,
+                        isIsometric: logExport.isIsometric,
+                        section: logExport.section
+                    )
+                    log.notes = logExport.notes
+                    log.session = session
+                    modelContext.insert(log)
+
+                    for setExport in logExport.sets {
+                        let setLog = SetLog(
+                            setNumber: setExport.setNumber,
+                            reps: setExport.reps,
+                            seconds: setExport.seconds,
+                            weightKg: setExport.weightKg,
+                            setType: SetType(rawValue: setExport.setType) ?? .normal
+                        )
+                        setLog.isCompleted = setExport.isCompleted
+                        setLog.isPersonalRecord = setExport.isPersonalRecord
+                        setLog.exerciseLog = log
+                        modelContext.insert(setLog)
+                    }
+                }
+            }
+        }
+
+        // Restore custom exercises
+        for ceExport in backup.customExercises {
+            if mode == .merge && existingCustomNames.contains(ceExport.name) {
+                continue
+            }
+            let ce = CustomExercise(
+                name: ceExport.name,
+                category: ceExport.category,
+                defaultSets: ceExport.defaultSets,
+                defaultReps: ceExport.defaultReps,
+                isIsometric: ceExport.isIsometric,
+                defaultSeconds: ceExport.defaultSeconds
+            )
+            modelContext.insert(ce)
+        }
+
+        try modelContext.save()
+    }
+
+    // MARK: - Helpers
+
+    private static func deleteAllData(modelContext: ModelContext) throws {
+        try modelContext.delete(model: WorkoutSession.self)
+        try modelContext.delete(model: ExerciseLog.self)
+        try modelContext.delete(model: SetLog.self)
+        try modelContext.delete(model: Exercise.self)
+        try modelContext.delete(model: WorkoutPlan.self)
+        try modelContext.delete(model: CustomExercise.self)
+    }
+
+    private static func fetchExistingPlanNames(modelContext: ModelContext) -> [String] {
+        let descriptor = FetchDescriptor<WorkoutPlan>()
+        return (try? modelContext.fetch(descriptor).map(\.name)) ?? []
+    }
+
+    private static func fetchExistingCustomExerciseNames(modelContext: ModelContext) -> [String] {
+        let descriptor = FetchDescriptor<CustomExercise>()
+        return (try? modelContext.fetch(descriptor).map(\.name)) ?? []
+    }
+}

--- a/OneTrack/Views/Workouts/ExportImportView.swift
+++ b/OneTrack/Views/Workouts/ExportImportView.swift
@@ -1,0 +1,207 @@
+import SwiftUI
+import SwiftData
+import UniformTypeIdentifiers
+
+struct ExportImportView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Environment(\.dismiss) private var dismiss
+
+    @Query(sort: \WorkoutPlan.sortOrder) private var plans: [WorkoutPlan]
+    @Query(filter: #Predicate<WorkoutSession> { $0.isCompleted },
+           sort: \WorkoutSession.date, order: .reverse)
+    private var sessions: [WorkoutSession]
+    @Query(sort: \CustomExercise.name) private var customExercises: [CustomExercise]
+
+    @State private var showShareSheet = false
+    @State private var exportData: Data?
+    @State private var showFileImporter = false
+    @State private var importPreview: WorkoutBackup?
+    @State private var showImportConfirmation = false
+    @State private var importMode: WorkoutDataExporter.ImportMode = .merge
+    @State private var errorMessage: String?
+    @State private var showError = false
+    @State private var showSuccess = false
+    @State private var successMessage = ""
+
+    var body: some View {
+        List {
+            // Export section
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("Export Workout Data", systemImage: "square.and.arrow.up")
+                        .font(.headline)
+                    Text("\(plans.count) plans, \(sessions.count) sessions, \(customExercises.count) custom exercises")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button {
+                    exportJSON()
+                } label: {
+                    Label("Export as JSON", systemImage: "doc.text")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                }
+                .buttonStyle(.borderedProminent)
+            } footer: {
+                Text("Creates a JSON file you can save to Files, email, or AirDrop.")
+            }
+
+            // Import section
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    Label("Import Workout Data", systemImage: "square.and.arrow.down")
+                        .font(.headline)
+                    Text("Restore from a previously exported JSON file.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Button {
+                    showFileImporter = true
+                } label: {
+                    Label("Import from File", systemImage: "doc.badge.plus")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                }
+                .buttonStyle(.bordered)
+            }
+
+            // Import preview
+            if let preview = importPreview {
+                Section("Import Preview") {
+                    LabeledContent("Plans", value: "\(preview.plans.count)")
+                    LabeledContent("Sessions", value: "\(preview.sessions.count)")
+                    LabeledContent("Custom Exercises", value: "\(preview.customExercises.count)")
+                    LabeledContent("Exported", value: preview.exportDate.shortDateTime)
+
+                    Picker("Import Mode", selection: $importMode) {
+                        Text("Merge (skip duplicates)").tag(WorkoutDataExporter.ImportMode.merge)
+                        Text("Replace all data").tag(WorkoutDataExporter.ImportMode.replace)
+                    }
+                    .pickerStyle(.menu)
+
+                    Button {
+                        showImportConfirmation = true
+                    } label: {
+                        Label("Import", systemImage: "checkmark.circle.fill")
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .tint(.green)
+                }
+            }
+        }
+        .navigationTitle("Export / Import")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button("Done") { dismiss() }
+            }
+        }
+        .fileImporter(isPresented: $showFileImporter, allowedContentTypes: [.json]) { result in
+            handleFileImport(result)
+        }
+        .sheet(isPresented: $showShareSheet) {
+            if let data = exportData {
+                ShareSheet(data: data, filename: "OneTrack-Backup-\(Date.now.formatted(.dateTime.year().month().day())).json")
+            }
+        }
+        .confirmationDialog(
+            importMode == .replace ? "Replace All Data?" : "Merge Data?",
+            isPresented: $showImportConfirmation
+        ) {
+            Button(importMode == .replace ? "Replace All" : "Merge", role: importMode == .replace ? .destructive : nil) {
+                performImport()
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            if importMode == .replace {
+                Text("This will delete ALL existing workout data and replace it with the imported data. This cannot be undone.")
+            } else {
+                Text("Plans with the same name will be skipped. New plans and sessions will be added.")
+            }
+        }
+        .alert("Error", isPresented: $showError) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(errorMessage ?? "An unknown error occurred.")
+        }
+        .alert("Import Complete", isPresented: $showSuccess) {
+            Button("OK", role: .cancel) { dismiss() }
+        } message: {
+            Text(successMessage)
+        }
+    }
+
+    // MARK: - Export
+
+    private func exportJSON() {
+        let backup = WorkoutDataExporter.export(
+            plans: plans,
+            sessions: sessions,
+            customExercises: customExercises
+        )
+        do {
+            exportData = try WorkoutDataExporter.exportJSON(backup: backup)
+            showShareSheet = true
+        } catch {
+            errorMessage = "Failed to export: \(error.localizedDescription)"
+            showError = true
+        }
+    }
+
+    // MARK: - Import
+
+    private func handleFileImport(_ result: Result<URL, Error>) {
+        switch result {
+        case .success(let url):
+            guard url.startAccessingSecurityScopedResource() else {
+                errorMessage = "Cannot access the selected file."
+                showError = true
+                return
+            }
+            defer { url.stopAccessingSecurityScopedResource() }
+
+            do {
+                let data = try Data(contentsOf: url)
+                importPreview = try WorkoutDataExporter.importJSON(data: data)
+            } catch {
+                errorMessage = "Invalid backup file: \(error.localizedDescription)"
+                showError = true
+            }
+        case .failure(let error):
+            errorMessage = "File selection failed: \(error.localizedDescription)"
+            showError = true
+        }
+    }
+
+    private func performImport() {
+        guard let backup = importPreview else { return }
+        do {
+            try WorkoutDataExporter.restore(backup: backup, modelContext: modelContext, mode: importMode)
+            successMessage = "Imported \(backup.plans.count) plans and \(backup.sessions.count) sessions."
+            importPreview = nil
+            showSuccess = true
+        } catch {
+            errorMessage = "Import failed: \(error.localizedDescription)"
+            showError = true
+        }
+    }
+}
+
+// MARK: - Share Sheet
+
+struct ShareSheet: UIViewControllerRepresentable {
+    let data: Data
+    let filename: String
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+        try? data.write(to: tempURL)
+        return UIActivityViewController(activityItems: [tempURL], applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
+}

--- a/OneTrack/Views/Workouts/WorkoutsTabView.swift
+++ b/OneTrack/Views/Workouts/WorkoutsTabView.swift
@@ -5,6 +5,7 @@ struct WorkoutsTabView: View {
     @State private var showingHistory = false
     @State private var showingCreatePlan = false
     @State private var showingImport = false
+    @State private var showingExportImport = false
 
     var body: some View {
         NavigationStack {
@@ -27,6 +28,14 @@ struct WorkoutsTabView: View {
                                 showingImport = true
                             } label: {
                                 Label("Import from Text", systemImage: "doc.text")
+                            }
+
+                            Divider()
+
+                            Button {
+                                showingExportImport = true
+                            } label: {
+                                Label("Export / Import Data", systemImage: "arrow.up.arrow.down.circle")
                             }
                         } label: {
                             Image(systemName: "plus")
@@ -52,6 +61,11 @@ struct WorkoutsTabView: View {
                 .sheet(isPresented: $showingImport) {
                     NavigationStack {
                         ImportPlanView()
+                    }
+                }
+                .sheet(isPresented: $showingExportImport) {
+                    NavigationStack {
+                        ExportImportView()
                     }
                 }
         }

--- a/OneTrackTests/Workouts/WorkoutDataExporterTests.swift
+++ b/OneTrackTests/Workouts/WorkoutDataExporterTests.swift
@@ -1,0 +1,248 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import OneTrack
+
+@Suite("Workout Data Exporter")
+@MainActor
+struct WorkoutDataExporterTests {
+
+    // MARK: - Export
+
+    @Test func exportPlansWithExercises() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let plan = WorkoutPlan(name: "Push Day", planDescription: "Chest focus", sortOrder: 0, defaultRestSeconds: 120)
+        plan.knownGroups = ["Main", "Accessories"]
+        context.insert(plan)
+
+        let ex1 = Exercise(name: "Bench Press", targetSets: 4, targetReps: 10, sortOrder: 0, section: "Main")
+        ex1.plan = plan
+        context.insert(ex1)
+
+        let ex2 = Exercise(name: "Plank", targetSets: 3, targetReps: 0, sortOrder: 1, isIsometric: true, targetSeconds: 60, section: "Accessories")
+        ex2.plan = plan
+        context.insert(ex2)
+        try context.save()
+
+        let backup = WorkoutDataExporter.export(plans: [plan], sessions: [], customExercises: [])
+
+        #expect(backup.plans.count == 1)
+        #expect(backup.plans[0].name == "Push Day")
+        #expect(backup.plans[0].defaultRestSeconds == 120)
+        #expect(backup.plans[0].knownGroups == ["Main", "Accessories"])
+        #expect(backup.plans[0].exercises.count == 2)
+        #expect(backup.plans[0].exercises[0].name == "Bench Press")
+        #expect(backup.plans[0].exercises[1].isIsometric)
+        #expect(backup.plans[0].exercises[1].targetSeconds == 60)
+    }
+
+    @Test func exportSessionsWithSets() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let plan = WorkoutPlan(name: "Legs", planDescription: "", sortOrder: 0)
+        context.insert(plan)
+
+        let session = WorkoutSession(date: .now, plan: plan)
+        session.isCompleted = true
+        session.durationSeconds = 3600
+        session.rpe = 8
+        session.notes = "Felt strong"
+        context.insert(session)
+
+        let log = ExerciseLog(exerciseName: "Squat", sortOrder: 0)
+        log.session = session
+        log.notes = "Go deeper"
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 5, weightKg: 100)
+        set1.isCompleted = true
+        set1.isPersonalRecord = true
+        set1.exerciseLog = log
+        context.insert(set1)
+
+        let set2 = SetLog(setNumber: 2, reps: 5, weightKg: 100, setType: .dropSet)
+        set2.isCompleted = true
+        set2.exerciseLog = log
+        context.insert(set2)
+        try context.save()
+
+        let backup = WorkoutDataExporter.export(plans: [plan], sessions: [session], customExercises: [])
+
+        #expect(backup.sessions.count == 1)
+        #expect(backup.sessions[0].planName == "Legs")
+        #expect(backup.sessions[0].rpe == 8)
+        #expect(backup.sessions[0].notes == "Felt strong")
+        #expect(backup.sessions[0].exercises[0].notes == "Go deeper")
+        #expect(backup.sessions[0].exercises[0].sets.count == 2)
+        #expect(backup.sessions[0].exercises[0].sets[0].isPersonalRecord)
+        #expect(backup.sessions[0].exercises[0].sets[1].setType == "dropSet")
+    }
+
+    @Test func exportCustomExercises() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let ce = CustomExercise(name: "Hip Thrust", category: "Legs", defaultSets: 4, defaultReps: 12)
+        context.insert(ce)
+        try context.save()
+
+        let backup = WorkoutDataExporter.export(plans: [], sessions: [], customExercises: [ce])
+
+        #expect(backup.customExercises.count == 1)
+        #expect(backup.customExercises[0].name == "Hip Thrust")
+        #expect(backup.customExercises[0].category == "Legs")
+    }
+
+    // MARK: - JSON Round-Trip
+
+    @Test func roundTrip_preservesAllData() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let plan = WorkoutPlan(name: "Test Plan", planDescription: "A plan", sortOrder: 0, defaultRestSeconds: 90)
+        plan.knownGroups = ["Group A"]
+        context.insert(plan)
+
+        let ex = Exercise(name: "Bench", targetSets: 3, targetReps: 10, sortOrder: 0, section: "Group A")
+        ex.plan = plan
+        context.insert(ex)
+
+        let session = WorkoutSession(date: .now, plan: plan)
+        session.isCompleted = true
+        session.durationSeconds = 1800
+        context.insert(session)
+
+        let log = ExerciseLog(exerciseName: "Bench", sortOrder: 0)
+        log.session = session
+        context.insert(log)
+
+        let setLog = SetLog(setNumber: 1, reps: 10, weightKg: 80)
+        setLog.isCompleted = true
+        setLog.exerciseLog = log
+        context.insert(setLog)
+
+        let ce = CustomExercise(name: "Custom Ex", category: "Other")
+        context.insert(ce)
+        try context.save()
+
+        // Export
+        let backup = WorkoutDataExporter.export(plans: [plan], sessions: [session], customExercises: [ce])
+        let json = try WorkoutDataExporter.exportJSON(backup: backup)
+
+        // Import
+        let restored = try WorkoutDataExporter.importJSON(data: json)
+
+        #expect(restored.plans.count == 1)
+        #expect(restored.plans[0].name == "Test Plan")
+        #expect(restored.plans[0].knownGroups == ["Group A"])
+        #expect(restored.plans[0].exercises.count == 1)
+        #expect(restored.sessions.count == 1)
+        #expect(restored.sessions[0].exercises[0].sets.count == 1)
+        #expect(restored.sessions[0].exercises[0].sets[0].weightKg == 80)
+        #expect(restored.customExercises.count == 1)
+        #expect(restored.customExercises[0].name == "Custom Ex")
+    }
+
+    // MARK: - Import
+
+    @Test func importEmptyBackup() throws {
+        let backup = WorkoutBackup(
+            exportDate: .now,
+            appVersion: "1.0",
+            plans: [],
+            sessions: [],
+            customExercises: []
+        )
+        let json = try WorkoutDataExporter.exportJSON(backup: backup)
+        let restored = try WorkoutDataExporter.importJSON(data: json)
+
+        #expect(restored.plans.isEmpty)
+        #expect(restored.sessions.isEmpty)
+        #expect(restored.customExercises.isEmpty)
+    }
+
+    @Test func importMalformedJSON() {
+        let badJSON = Data("{ invalid json }".utf8)
+        #expect(throws: DecodingError.self) {
+            try WorkoutDataExporter.importJSON(data: badJSON)
+        }
+    }
+
+    @Test func restoreReplace() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        // Pre-existing data
+        let existingPlan = WorkoutPlan(name: "Old Plan", planDescription: "", sortOrder: 0)
+        context.insert(existingPlan)
+        try context.save()
+
+        // Backup to import
+        let backup = WorkoutBackup(
+            exportDate: .now,
+            appVersion: "1.0",
+            plans: [
+                WorkoutBackup.PlanExport(
+                    name: "New Plan",
+                    description: "",
+                    sortOrder: 0,
+                    defaultRestSeconds: 90,
+                    knownGroups: [],
+                    exercises: []
+                )
+            ],
+            sessions: [],
+            customExercises: []
+        )
+
+        try WorkoutDataExporter.restore(backup: backup, modelContext: context, mode: .replace)
+
+        let plans = try context.fetch(FetchDescriptor<WorkoutPlan>())
+        #expect(plans.count == 1)
+        #expect(plans[0].name == "New Plan")
+    }
+
+    @Test func restoreMergeSkipsDuplicates() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let existingPlan = WorkoutPlan(name: "Keep Me", planDescription: "original", sortOrder: 0)
+        context.insert(existingPlan)
+        try context.save()
+
+        let backup = WorkoutBackup(
+            exportDate: .now,
+            appVersion: "1.0",
+            plans: [
+                WorkoutBackup.PlanExport(
+                    name: "Keep Me",
+                    description: "imported",
+                    sortOrder: 0,
+                    defaultRestSeconds: 90,
+                    knownGroups: [],
+                    exercises: []
+                ),
+                WorkoutBackup.PlanExport(
+                    name: "New Plan",
+                    description: "",
+                    sortOrder: 1,
+                    defaultRestSeconds: 90,
+                    knownGroups: [],
+                    exercises: []
+                )
+            ],
+            sessions: [],
+            customExercises: []
+        )
+
+        try WorkoutDataExporter.restore(backup: backup, modelContext: context, mode: .merge)
+
+        let plans = try context.fetch(FetchDescriptor<WorkoutPlan>())
+        #expect(plans.count == 2) // original + new, not duplicate
+        let keepMe = plans.first(where: { $0.name == "Keep Me" })
+        #expect(keepMe?.planDescription == "original") // not overwritten
+    }
+}


### PR DESCRIPTION
## Summary

Full data backup/restore via JSON file export and import.

### Export
- Serializes all workout plans, exercises, completed sessions (with sets, PRs, set types), and custom exercises
- JSON with ISO 8601 dates, pretty-printed for readability
- Share sheet (UIActivityViewController) for saving to Files, AirDrop, email

### Import
- File picker for `.json` files
- Preview shows plan/session/custom exercise counts before confirming
- **Merge mode**: skips plans with duplicate names, adds only new data
- **Replace mode**: deletes ALL existing data and replaces (with destructive confirmation)

### Access
- WorkoutsTabView "+" menu → "Export / Import Data"

## New Files
- `OneTrack/Utilities/WorkoutDataExporter.swift` — export/import/restore logic + Codable types
- `OneTrack/Views/Workouts/ExportImportView.swift` — UI with share sheet + file picker
- `OneTrackTests/Workouts/WorkoutDataExporterTests.swift` — 8 tests

## Test plan
- [x] 201 tests pass locally (0 failures)
- [ ] CI passes
- [ ] Export → opens share sheet with JSON file
- [ ] Import merge → skips existing plans, adds new
- [ ] Import replace → deletes all, restores from backup
- [ ] Round-trip: export → import → data identical

Closes #7