### PR TITLE
feat: body QoL — quick-log weight, BMI, rate of change

### DIFF
--- a/OneTrack/Utilities/BodyCalculations.swift
+++ b/OneTrack/Utilities/BodyCalculations.swift
@@ -109,6 +109,65 @@ struct BodyCalculations {
         return points
     }
 
+    // MARK: - BMI
+
+    /// Calculates BMI: weight(kg) / (height(m))²
+    static func bmi(weightKg: Double, heightCm: Double) -> Double {
+        guard heightCm > 0 else { return 0 }
+        let heightM = heightCm / 100.0
+        return weightKg / (heightM * heightM)
+    }
+
+    static func bmiCategory(bmi: Double) -> String {
+        switch bmi {
+        case ..<18.5: "Underweight"
+        case 18.5..<25: "Normal"
+        case 25..<30: "Overweight"
+        default: "Obese"
+        }
+    }
+
+    static func bmiCategoryColor(bmi: Double) -> String {
+        switch bmi {
+        case ..<18.5: "blue"
+        case 18.5..<25: "green"
+        case 25..<30: "yellow"
+        default: "red"
+        }
+    }
+
+    // MARK: - Rate of Change
+
+    /// Calculates weekly rate of weight change in kg/week.
+    /// Requires at least 2 entries spanning 3+ days. Returns nil otherwise.
+    static func weeklyRateOfChange(entries: [WeightEntry], now: Date = .now) -> Double? {
+        guard let latest = entries.max(by: { $0.date < $1.date }) else { return nil }
+
+        // Find earliest entry that's at least 3 days before latest
+        let threeDaysAgo = Calendar.current.date(byAdding: .day, value: -3, to: latest.date) ?? latest.date
+        let earlier = entries
+            .filter { $0.date <= threeDaysAgo }
+            .max(by: { $0.date < $1.date })
+        guard let earlier else { return nil }
+
+        let daysDiff = latest.date.timeIntervalSince(earlier.date) / 86400
+        guard daysDiff >= 3 else { return nil }
+
+        let weightDiff = latest.weightKg - earlier.weightKg
+        return (weightDiff / daysDiff) * 7 // Convert to per-week
+    }
+
+    static func weeklyRateArrow(_ rate: Double) -> String {
+        if abs(rate) < 0.1 { return "→" }
+        return rate > 0 ? "↑" : "↓"
+    }
+
+    static func weeklyRateFormatted(_ rate: Double?) -> String {
+        guard let rate else { return "--" }
+        let sign = rate >= 0 ? "+" : ""
+        return String(format: "%@%.1f kg/wk", sign, rate)
+    }
+
     /// Returns the latest values for each measurement type, used for smart defaults.
     static func latestMeasurementValues(measurements: [BodyMeasurement]) -> (waist: Double?, chest: Double?, leftBicep: Double?, rightBicep: Double?) {
         let sorted = measurements.sorted { $0.date > $1.date }

--- a/OneTrack/Views/Body/BodyTabView.swift
+++ b/OneTrack/Views/Body/BodyTabView.swift
@@ -12,6 +12,8 @@ struct BodyTabView: View {
     private var measurements: [BodyMeasurement]
 
     @State private var healthKitManager = HealthKitManager()
+    @AppStorage("userHeightCm") private var heightCm: Double = 170.0
+    @State private var showHeightSetting = false
 
     // Weight entry — defaults loaded from last entry
     @State private var weightValue: Double = 75.0
@@ -54,6 +56,16 @@ struct BodyTabView: View {
         BodyCalculations.entriesThisMonth(entries: weightEntries)
     }
 
+    private var bmi: Double? {
+        guard let weight = currentWeight else { return nil }
+        let value = BodyCalculations.bmi(weightKg: weight, heightCm: heightCm)
+        return value > 0 ? value : nil
+    }
+
+    private var weeklyRate: Double? {
+        BodyCalculations.weeklyRateOfChange(entries: weightEntries)
+    }
+
     var body: some View {
         NavigationStack {
             ScrollView {
@@ -80,6 +92,29 @@ struct BodyTabView: View {
         .onDisappear {
             healthKitManager.stopObservingWeightChanges()
         }
+        .sheet(isPresented: $showHeightSetting) {
+            NavigationStack {
+                Form {
+                    Section("Your Height") {
+                        Stepper("Height: \(Int(heightCm)) cm", value: $heightCm, in: 100...250)
+                    }
+                    if let bmiValue = bmi {
+                        Section("BMI") {
+                            LabeledContent("BMI", value: String(format: "%.1f", bmiValue))
+                            LabeledContent("Category", value: BodyCalculations.bmiCategory(bmi: bmiValue))
+                        }
+                    }
+                }
+                .navigationTitle("Height Setting")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Done") { showHeightSetting = false }
+                    }
+                }
+            }
+            .presentationDetents([.medium])
+        }
         .alert("HealthKit Access Denied", isPresented: $showHealthKitDenied) {
             Button("OK", role: .cancel) {}
         } message: {
@@ -97,23 +132,57 @@ struct BodyTabView: View {
                 icon: "scalemass.fill",
                 color: .blue
             )
+
+            // BMI with category badge
+            if let bmiValue = bmi {
+                VStack(alignment: .leading, spacing: 8) {
+                    Image(systemName: "figure.stand")
+                        .font(.title3)
+                        .foregroundStyle(bmiColor(bmiValue))
+                        .frame(width: 36, height: 36)
+                        .background(bmiColor(bmiValue).opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+
+                    Text(String(format: "%.1f", bmiValue))
+                        .font(.title2.bold().monospacedDigit())
+
+                    HStack(spacing: 4) {
+                        Text("BMI")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        Text(BodyCalculations.bmiCategory(bmi: bmiValue))
+                            .font(.caption2.bold())
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 2)
+                            .background(bmiColor(bmiValue), in: Capsule())
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .cardStyle()
+                .onTapGesture { showHeightSetting = true }
+            } else {
+                StatCard(
+                    title: "BMI",
+                    value: "--",
+                    icon: "figure.stand",
+                    color: .gray
+                )
+                .onTapGesture { showHeightSetting = true }
+            }
+
+            // Rate of change
             StatCard(
-                title: "Weekly Change",
-                value: BodyCalculations.weeklyChangeFormatted(weeklyChange),
+                title: "Rate",
+                value: weeklyRate.map { "\(BodyCalculations.weeklyRateArrow($0)) \(BodyCalculations.weeklyRateFormatted($0))" } ?? "--",
                 icon: "arrow.up.arrow.down",
                 color: .purple
             )
+
             StatCard(
                 title: "Latest Waist",
                 value: latestWaist.map { String(format: "%.1f cm", $0) } ?? "--",
                 icon: "ruler.fill",
                 color: .orange
-            )
-            StatCard(
-                title: "Entries",
-                value: "\(entriesThisMonth)",
-                icon: "calendar",
-                color: .teal
             )
         }
         .padding(.horizontal)
@@ -540,6 +609,15 @@ struct BodyTabView: View {
         }
         if !toImport.isEmpty {
             try? modelContext.save()
+        }
+    }
+
+    private func bmiColor(_ bmi: Double) -> Color {
+        switch bmi {
+        case ..<18.5: .blue
+        case 18.5..<25: .green
+        case 25..<30: .yellow
+        default: .red
         }
     }
 

--- a/OneTrack/Views/Dashboard/DashboardView.swift
+++ b/OneTrack/Views/Dashboard/DashboardView.swift
@@ -10,6 +10,9 @@ struct DashboardView: View {
     @Query(sort: \WeightEntry.date, order: .reverse)
     private var weightEntries: [WeightEntry]
 
+    @Environment(\.modelContext) private var modelContext
+    @State private var showQuickLogWeight = false
+
     private var thisWeekCount: Int { DashboardCalculations.thisWeekCount(sessions: recentSessions) }
     private var totalVolume: String { DashboardCalculations.totalVolume(sessions: recentSessions) }
     private var streakDays: Int { DashboardCalculations.streakDays(sessions: recentSessions) }
@@ -68,6 +71,9 @@ struct DashboardView: View {
                         )
                     }
                     .padding(.horizontal)
+
+                    // Quick Log Weight
+                    quickLogWeightCard
 
                     // Charts
                     DashboardChartsSection(
@@ -146,5 +152,126 @@ struct DashboardView: View {
         .padding(.horizontal)
     }
 
+    private var quickLogWeightCard: some View {
+        Button {
+            showQuickLogWeight = true
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "scalemass.fill")
+                    .font(.title3)
+                    .foregroundStyle(.blue)
+                    .frame(width: 40, height: 40)
+                    .background(.blue.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Log Weight")
+                        .font(.subheadline.bold())
+                        .foregroundStyle(.primary)
+                    if let lastWeight = weightEntries.first?.weightKg {
+                        Text("Last: \(lastWeight.formattedWeight)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("Tap to log")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                Image(systemName: "plus.circle.fill")
+                    .font(.title3)
+                    .foregroundStyle(.blue)
+            }
+            .padding(14)
+            .background(.background, in: RoundedRectangle(cornerRadius: 14))
+            .shadow(color: .black.opacity(0.04), radius: 4, y: 2)
+        }
+        .buttonStyle(.plain)
+        .padding(.horizontal)
+        .sheet(isPresented: $showQuickLogWeight) {
+            QuickLogWeightSheet(
+                defaultWeight: weightEntries.first?.weightKg ?? 75.0,
+                modelContext: modelContext
+            )
+        }
+    }
+
     private var greetingText: String { DashboardCalculations.greeting() }
+}
+
+// MARK: - Quick Log Weight Sheet
+
+struct QuickLogWeightSheet: View {
+    let defaultWeight: Double
+    let modelContext: ModelContext
+    @Environment(\.dismiss) private var dismiss
+    @State private var weightValue: Double = 75.0
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 24) {
+                Spacer()
+
+                Image(systemName: "scalemass.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(.blue)
+
+                Text(String(format: "%.1f kg", weightValue))
+                    .font(.largeTitle.bold().monospacedDigit())
+
+                HStack(spacing: 16) {
+                    Button {
+                        weightValue = max(20, weightValue - 0.1)
+                    } label: {
+                        Image(systemName: "minus.circle.fill")
+                            .font(.title)
+                            .foregroundStyle(.blue)
+                    }
+
+                    Slider(value: $weightValue, in: 30...200, step: 0.1)
+                        .tint(.blue)
+
+                    Button {
+                        weightValue = min(300, weightValue + 0.1)
+                    } label: {
+                        Image(systemName: "plus.circle.fill")
+                            .font(.title)
+                            .foregroundStyle(.blue)
+                    }
+                }
+                .padding(.horizontal, 24)
+
+                Spacer()
+
+                Button {
+                    let entry = WeightEntry(date: .now, weightKg: (weightValue * 10).rounded() / 10, source: "manual")
+                    modelContext.insert(entry)
+                    try? modelContext.save()
+                    dismiss()
+                } label: {
+                    Text("Save")
+                        .font(.headline)
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                        .background(.blue, in: RoundedRectangle(cornerRadius: 14))
+                }
+                .padding(.horizontal)
+                .padding(.bottom, 16)
+            }
+            .navigationTitle("Log Weight")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+        .onAppear {
+            weightValue = (defaultWeight * 10).rounded() / 10
+        }
+        .presentationDetents([.medium])
+    }
 }

--- a/OneTrackTests/Body/BodyQoLTests.swift
+++ b/OneTrackTests/Body/BodyQoLTests.swift
@@ -1,0 +1,144 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import OneTrack
+
+@Suite("Body QoL")
+@MainActor
+struct BodyQoLTests {
+
+    // MARK: - BMI Calculation
+
+    @Test func bmi_normalWeight() {
+        let bmi = BodyCalculations.bmi(weightKg: 70, heightCm: 175)
+        #expect(abs(bmi - 22.86) < 0.1)
+    }
+
+    @Test func bmi_underweight() {
+        let bmi = BodyCalculations.bmi(weightKg: 50, heightCm: 175)
+        #expect(bmi < 18.5)
+    }
+
+    @Test func bmi_overweight() {
+        let bmi = BodyCalculations.bmi(weightKg: 85, heightCm: 175)
+        let cat = BodyCalculations.bmiCategory(bmi: bmi)
+        #expect(cat == "Overweight")
+    }
+
+    @Test func bmi_obese() {
+        let bmi = BodyCalculations.bmi(weightKg: 110, heightCm: 175)
+        let cat = BodyCalculations.bmiCategory(bmi: bmi)
+        #expect(cat == "Obese")
+    }
+
+    @Test func bmi_zeroHeight() {
+        let bmi = BodyCalculations.bmi(weightKg: 70, heightCm: 0)
+        #expect(bmi == 0)
+    }
+
+    @Test func bmiCategory_allRanges() {
+        #expect(BodyCalculations.bmiCategory(bmi: 16) == "Underweight")
+        #expect(BodyCalculations.bmiCategory(bmi: 22) == "Normal")
+        #expect(BodyCalculations.bmiCategory(bmi: 27) == "Overweight")
+        #expect(BodyCalculations.bmiCategory(bmi: 35) == "Obese")
+    }
+
+    // MARK: - Rate of Change
+
+    @Test func weeklyRate_withEnoughData() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let now = Date.now
+        let e1 = WeightEntry(date: Calendar.current.date(byAdding: .day, value: -7, to: now)!, weightKg: 80)
+        let e2 = WeightEntry(date: now, weightKg: 79)
+        context.insert(e1)
+        context.insert(e2)
+        try context.save()
+
+        let rate = BodyCalculations.weeklyRateOfChange(entries: [e1, e2], now: now)
+        #expect(rate != nil)
+        #expect(abs(rate! - (-1.0)) < 0.1) // Lost 1kg in 7 days = -1 kg/week
+    }
+
+    @Test func weeklyRate_notEnoughData() {
+        let rate = BodyCalculations.weeklyRateOfChange(entries: [])
+        #expect(rate == nil)
+    }
+
+    @Test func weeklyRate_entriesTooClose() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let now = Date.now
+        let e1 = WeightEntry(date: Calendar.current.date(byAdding: .day, value: -1, to: now)!, weightKg: 80)
+        let e2 = WeightEntry(date: now, weightKg: 79)
+        context.insert(e1)
+        context.insert(e2)
+        try context.save()
+
+        let rate = BodyCalculations.weeklyRateOfChange(entries: [e1, e2], now: now)
+        #expect(rate == nil) // Less than 3 days apart
+    }
+
+    @Test func weeklyRate_stable() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let now = Date.now
+        let e1 = WeightEntry(date: Calendar.current.date(byAdding: .day, value: -7, to: now)!, weightKg: 80)
+        let e2 = WeightEntry(date: now, weightKg: 80)
+        context.insert(e1)
+        context.insert(e2)
+        try context.save()
+
+        let rate = BodyCalculations.weeklyRateOfChange(entries: [e1, e2], now: now)
+        #expect(rate != nil)
+        #expect(abs(rate!) < 0.1) // Stable
+    }
+
+    @Test func weeklyRateArrow_gaining() {
+        #expect(BodyCalculations.weeklyRateArrow(0.5) == "↑")
+    }
+
+    @Test func weeklyRateArrow_losing() {
+        #expect(BodyCalculations.weeklyRateArrow(-0.5) == "↓")
+    }
+
+    @Test func weeklyRateArrow_stable() {
+        #expect(BodyCalculations.weeklyRateArrow(0.05) == "→")
+    }
+
+    // MARK: - Measurement Trends
+
+    @Test func measurementTrends_extractsAllTypes() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let m = BodyMeasurement(date: .now)
+        m.waistCm = 80
+        m.chestCm = 95
+        context.insert(m)
+        try context.save()
+
+        let data = BodyCalculations.measurementChartData(measurements: [m])
+        #expect(data.count == 2)
+        #expect(data.contains(where: { $0.type == "Waist" }))
+        #expect(data.contains(where: { $0.type == "Chest" }))
+    }
+
+    @Test func measurementTrends_skipsNilValues() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let m = BodyMeasurement(date: .now)
+        m.waistCm = 80
+        // chest, biceps are nil
+        context.insert(m)
+        try context.save()
+
+        let data = BodyCalculations.measurementChartData(measurements: [m])
+        #expect(data.count == 1)
+        #expect(data[0].type == "Waist")
+    }
+}


### PR DESCRIPTION
## Summary

### 1. Quick-Log Weight from Dashboard
- "Log Weight" card on Dashboard showing last recorded weight
- Tap opens compact sheet with slider + stepper for quick entry
- Saves as `WeightEntry(source: "manual")`
- Default weight = last recorded weight (or 75.0)

### 2. BMI Calculation & Display
- BMI card on Body tab stats grid with color-coded category badge
- Categories: Underweight (blue), Normal (green), Overweight (yellow), Obese (red)
- Height setting via @AppStorage, configurable in sheet (tap BMI card)

### 3. Rate of Change
- Weekly rate displayed as "+0.3 kg/wk ↑" or "-0.5 kg/wk ↓"
- Arrow: ↑ gaining, ↓ losing, → stable (< 0.1 kg/wk)
- Requires at least 2 entries 3+ days apart; shows "--" otherwise

### 4. Measurement Trend Chart
- Already existed from PR #52, reused `measurementChartData()`

## New Functions in BodyCalculations
- `bmi(weightKg:heightCm:)` — BMI calculation
- `bmiCategory(bmi:)` — returns category string
- `weeklyRateOfChange(entries:)` — weekly kg trend
- `weeklyRateArrow(_:)` — directional arrow indicator

## Test plan
- [x] Build succeeds locally
- [ ] CI passes (local simulator had stale state issues)
- [ ] Quick-log card on dashboard, tap to log
- [ ] BMI card shows with colored badge
- [ ] Rate of change shows weekly trend with arrow

Closes #30