### PR TITLE
feat: reorder exercises and swap exercise mid-workout

### DIFF
--- a/OneTrack/Engine/WorkoutEngine.swift
+++ b/OneTrack/Engine/WorkoutEngine.swift
@@ -138,6 +138,36 @@ final class WorkoutEngine {
         try? modelContext.save()
     }
 
+    // MARK: - Reorder & Swap
+
+    /// Reorders exercises within the current session. Session-scoped only.
+    func reorderExercises(from source: IndexSet, to destination: Int) {
+        guard session != nil else { return }
+        var logs = sortedLogs
+        logs.move(fromOffsets: source, toOffset: destination)
+        for (index, log) in logs.enumerated() {
+            log.sortOrder = index
+        }
+        try? modelContext.save()
+    }
+
+    /// Swaps an exercise for an alternative. Preserves sets, clears PRs.
+    func swapExercise(_ log: ExerciseLog, with template: ExerciseTemplate) {
+        // Track the original exercise name (not intermediate swaps)
+        if log.swappedFromExercise.isEmpty {
+            log.swappedFromExercise = log.exerciseName
+        }
+        log.exerciseName = template.name
+        log.isIsometric = template.isIsometric
+
+        // Clear PR flags — different exercise can't retain old PRs
+        for set in log.sets {
+            set.isPersonalRecord = false
+        }
+
+        try? modelContext.save()
+    }
+
     // MARK: - Rest Timer
 
     func startRestTimer(duration: Int? = nil) {

--- a/OneTrack/Models/ExerciseLog.swift
+++ b/OneTrack/Models/ExerciseLog.swift
@@ -7,6 +7,7 @@ final class ExerciseLog {
     var isIsometric: Bool = false
     var section: String = ""
     var notes: String = ""
+    var swappedFromExercise: String = ""
     var sortOrder: Int = 0
     var session: WorkoutSession?
     @Relationship(deleteRule: .cascade, inverse: \SetLog.exerciseLog)

--- a/OneTrack/Views/Workouts/ActiveWorkoutView.swift
+++ b/OneTrack/Views/Workouts/ActiveWorkoutView.swift
@@ -16,6 +16,11 @@ struct ActiveWorkoutView: View {
     // PR celebration (UI-only)
     @State private var showConfetti = false
 
+    // Exercise swap & reorder
+    @State private var exerciseToSwap: ExerciseLog?
+    @State private var showSwapPicker = false
+    @State private var showReorderSheet = false
+
     // Convenience accessors delegating to engine
     private var sortedLogs: [ExerciseLog] { engine?.sortedLogs ?? [] }
     private var completedCount: Int { engine?.completedCount ?? 0 }
@@ -66,7 +71,11 @@ struct ActiveWorkoutView: View {
                                     triggerPRCelebration()
                                 },
                                 onAddSet: { addSet(to: log) },
-                                onDeleteSet: { setLog in deleteSet(setLog, from: log) }
+                                onDeleteSet: { setLog in deleteSet(setLog, from: log) },
+                                onSwapExercise: {
+                                    exerciseToSwap = log
+                                    showSwapPicker = true
+                                }
                             )
                         }
                     }
@@ -116,15 +125,24 @@ struct ActiveWorkoutView: View {
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    showFinishConfirmation = true
-                } label: {
-                    Text("Finish")
-                        .font(.headline)
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 6)
-                        .background(.green, in: Capsule())
+                HStack(spacing: 12) {
+                    Button {
+                        showReorderSheet = true
+                    } label: {
+                        Image(systemName: "arrow.up.arrow.down")
+                            .font(.subheadline)
+                    }
+
+                    Button {
+                        showFinishConfirmation = true
+                    } label: {
+                        Text("Finish")
+                            .font(.headline)
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 6)
+                            .background(.green, in: Capsule())
+                    }
                 }
             }
         }
@@ -151,6 +169,43 @@ struct ActiveWorkoutView: View {
             ExercisePickerView { templates in
                 addExercises(templates)
             }
+        }
+        .sheet(isPresented: $showSwapPicker) {
+            ExercisePickerView { templates in
+                if let template = templates.first, let log = exerciseToSwap {
+                    engine?.swapExercise(log, with: template)
+                }
+                exerciseToSwap = nil
+            }
+        }
+        .sheet(isPresented: $showReorderSheet) {
+            NavigationStack {
+                List {
+                    ForEach(sortedLogs) { log in
+                        HStack {
+                            if !log.swappedFromExercise.isEmpty {
+                                Image(systemName: "arrow.triangle.swap")
+                                    .font(.caption2)
+                                    .foregroundStyle(.orange)
+                            }
+                            Text(log.exerciseName)
+                                .font(.subheadline)
+                        }
+                    }
+                    .onMove { from, to in
+                        engine?.reorderExercises(from: from, to: to)
+                    }
+                }
+                .environment(\.editMode, .constant(.active))
+                .navigationTitle("Reorder Exercises")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button("Done") { showReorderSheet = false }
+                    }
+                }
+            }
+            .presentationDetents([.medium])
         }
         .onAppear {
             if engine == nil {
@@ -328,6 +383,7 @@ private struct ExerciseSectionView: View {
     let onPRDetected: () -> Void
     let onAddSet: () -> Void
     let onDeleteSet: (SetLog) -> Void
+    let onSwapExercise: () -> Void
 
     @State private var showNotes = false
     @State private var showHistory = false
@@ -367,6 +423,27 @@ private struct ExerciseSectionView: View {
                     Text(log.exerciseName)
                         .font(.headline)
                         .onLongPressGesture { showHistory = true }
+                        .contextMenu {
+                            Button {
+                                onSwapExercise()
+                            } label: {
+                                Label("Swap Exercise", systemImage: "arrow.triangle.swap")
+                            }
+                            Button {
+                                showHistory = true
+                            } label: {
+                                Label("View History", systemImage: "chart.xyaxis.line")
+                            }
+                        }
+                    if !log.swappedFromExercise.isEmpty {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.triangle.swap")
+                                .font(.caption2)
+                            Text("from \(log.swappedFromExercise)")
+                                .font(.caption2)
+                        }
+                        .foregroundStyle(.orange)
+                    }
                     if let e1rm = estimated1RM {
                         Text("Est. 1RM: \(String(format: "%.1f", e1rm)) kg")
                             .font(.caption)

--- a/OneTrack/Views/Workouts/WorkoutSessionDetailView.swift
+++ b/OneTrack/Views/Workouts/WorkoutSessionDetailView.swift
@@ -60,11 +60,22 @@ struct WorkoutSessionDetailView: View {
                     Button {
                         exerciseForHistory = log.exerciseName
                     } label: {
-                        HStack {
-                            Text(log.exerciseName)
-                            Image(systemName: "chart.xyaxis.line")
-                                .font(.caption2)
-                                .foregroundStyle(.blue)
+                        VStack(alignment: .leading, spacing: 2) {
+                            HStack {
+                                Text(log.exerciseName)
+                                Image(systemName: "chart.xyaxis.line")
+                                    .font(.caption2)
+                                    .foregroundStyle(.blue)
+                            }
+                            if !log.swappedFromExercise.isEmpty {
+                                HStack(spacing: 4) {
+                                    Image(systemName: "arrow.triangle.swap")
+                                        .font(.caption2)
+                                    Text("from \(log.swappedFromExercise)")
+                                        .font(.caption2)
+                                }
+                                .foregroundStyle(.orange)
+                            }
                         }
                     }
                 }

--- a/OneTrackTests/Engine/WorkoutEngineReorderSwapTests.swift
+++ b/OneTrackTests/Engine/WorkoutEngineReorderSwapTests.swift
@@ -1,0 +1,252 @@
+import Testing
+import Foundation
+import SwiftData
+@testable import OneTrack
+
+@Suite("Workout Engine - Reorder & Swap")
+@MainActor
+struct WorkoutEngineReorderSwapTests {
+
+    // MARK: - Reorder
+
+    @Test func reorderExercises_moveFirstToLast() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let session = WorkoutSession()
+        context.insert(session)
+
+        let log1 = ExerciseLog(exerciseName: "Bench Press", sortOrder: 0)
+        log1.session = session
+        context.insert(log1)
+
+        let log2 = ExerciseLog(exerciseName: "Squat", sortOrder: 1)
+        log2.session = session
+        context.insert(log2)
+
+        let log3 = ExerciseLog(exerciseName: "Deadlift", sortOrder: 2)
+        log3.session = session
+        context.insert(log3)
+        try context.save()
+
+        let engine = WorkoutEngine(modelContext: context)
+        engine.resumeSession(session, previous: nil)
+
+        // Move Bench Press (index 0) to position 3 (end)
+        engine.reorderExercises(from: IndexSet(integer: 0), to: 3)
+
+        let sorted = engine.sortedLogs
+        #expect(sorted[0].exerciseName == "Squat")
+        #expect(sorted[1].exerciseName == "Deadlift")
+        #expect(sorted[2].exerciseName == "Bench Press")
+        #expect(sorted[0].sortOrder == 0)
+        #expect(sorted[1].sortOrder == 1)
+        #expect(sorted[2].sortOrder == 2)
+    }
+
+    @Test func reorderExercises_moveLastToFirst() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let session = WorkoutSession()
+        context.insert(session)
+
+        let log1 = ExerciseLog(exerciseName: "A", sortOrder: 0)
+        log1.session = session
+        context.insert(log1)
+
+        let log2 = ExerciseLog(exerciseName: "B", sortOrder: 1)
+        log2.session = session
+        context.insert(log2)
+
+        let log3 = ExerciseLog(exerciseName: "C", sortOrder: 2)
+        log3.session = session
+        context.insert(log3)
+        try context.save()
+
+        let engine = WorkoutEngine(modelContext: context)
+        engine.resumeSession(session, previous: nil)
+
+        // Move C (index 2) to position 0
+        engine.reorderExercises(from: IndexSet(integer: 2), to: 0)
+
+        let sorted = engine.sortedLogs
+        #expect(sorted[0].exerciseName == "C")
+        #expect(sorted[1].exerciseName == "A")
+        #expect(sorted[2].exerciseName == "B")
+    }
+
+    @Test func reorderExercises_doesNotModifyPlan() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let plan = WorkoutPlan(name: "Test", planDescription: "", sortOrder: 0)
+        context.insert(plan)
+
+        let ex1 = Exercise(name: "Bench", targetSets: 3, targetReps: 10, sortOrder: 0)
+        ex1.plan = plan
+        context.insert(ex1)
+        let ex2 = Exercise(name: "Squat", targetSets: 3, targetReps: 10, sortOrder: 1)
+        ex2.plan = plan
+        context.insert(ex2)
+
+        let session = WorkoutSession(plan: plan)
+        context.insert(session)
+
+        let log1 = ExerciseLog(exerciseName: "Bench", sortOrder: 0)
+        log1.session = session
+        context.insert(log1)
+        let log2 = ExerciseLog(exerciseName: "Squat", sortOrder: 1)
+        log2.session = session
+        context.insert(log2)
+        try context.save()
+
+        let engine = WorkoutEngine(modelContext: context)
+        engine.resumeSession(session, previous: nil)
+
+        engine.reorderExercises(from: IndexSet(integer: 0), to: 2)
+
+        // Plan exercises should remain unchanged
+        let planExercises = plan.exercises.sorted { $0.sortOrder < $1.sortOrder }
+        #expect(planExercises[0].name == "Bench")
+        #expect(planExercises[1].name == "Squat")
+    }
+
+    // MARK: - Swap
+
+    @Test func swapExercise_changesName() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let session = WorkoutSession()
+        context.insert(session)
+
+        let log = ExerciseLog(exerciseName: "Bench Press", sortOrder: 0)
+        log.session = session
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 10, weightKg: 80)
+        set1.exerciseLog = log
+        context.insert(set1)
+        try context.save()
+
+        let engine = WorkoutEngine(modelContext: context)
+        engine.resumeSession(session, previous: nil)
+
+        let replacement = ExerciseTemplate(name: "Dumbbell Press", category: "Chest", defaultSets: 3, defaultReps: 10)
+        engine.swapExercise(log, with: replacement)
+
+        #expect(log.exerciseName == "Dumbbell Press")
+        #expect(log.swappedFromExercise == "Bench Press")
+    }
+
+    @Test func swapExercise_preservesSets() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let session = WorkoutSession()
+        context.insert(session)
+
+        let log = ExerciseLog(exerciseName: "Bench Press", sortOrder: 0)
+        log.session = session
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 10, weightKg: 80)
+        set1.isCompleted = true
+        set1.exerciseLog = log
+        context.insert(set1)
+
+        let set2 = SetLog(setNumber: 2, reps: 8, weightKg: 85)
+        set2.exerciseLog = log
+        context.insert(set2)
+        try context.save()
+
+        let engine = WorkoutEngine(modelContext: context)
+        engine.resumeSession(session, previous: nil)
+
+        let replacement = ExerciseTemplate(name: "Incline Press", category: "Chest", defaultSets: 3, defaultReps: 10)
+        engine.swapExercise(log, with: replacement)
+
+        // Sets should be preserved
+        #expect(log.sets.count == 2)
+        #expect(log.sets.contains(where: { $0.weightKg == 80 }))
+        #expect(log.sets.contains(where: { $0.weightKg == 85 }))
+    }
+
+    @Test func swapExercise_clearsPRFlags() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let session = WorkoutSession()
+        context.insert(session)
+
+        let log = ExerciseLog(exerciseName: "Bench Press", sortOrder: 0)
+        log.session = session
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 10, weightKg: 100)
+        set1.isCompleted = true
+        set1.isPersonalRecord = true
+        set1.exerciseLog = log
+        context.insert(set1)
+        try context.save()
+
+        let engine = WorkoutEngine(modelContext: context)
+        engine.resumeSession(session, previous: nil)
+
+        let replacement = ExerciseTemplate(name: "OHP", category: "Shoulders", defaultSets: 3, defaultReps: 10)
+        engine.swapExercise(log, with: replacement)
+
+        #expect(!set1.isPersonalRecord) // PR cleared — different exercise
+    }
+
+    @Test func swapExercise_updatesIsometric() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let session = WorkoutSession()
+        context.insert(session)
+
+        let log = ExerciseLog(exerciseName: "Bench Press", sortOrder: 0)
+        log.session = session
+        context.insert(log)
+        try context.save()
+
+        let engine = WorkoutEngine(modelContext: context)
+        engine.resumeSession(session, previous: nil)
+
+        #expect(!log.isIsometric)
+
+        let isoTemplate = ExerciseTemplate(name: "Plank", category: "Core", defaultSets: 3, defaultReps: 0, isIsometric: true, defaultSeconds: 60)
+        engine.swapExercise(log, with: isoTemplate)
+
+        #expect(log.isIsometric)
+        #expect(log.exerciseName == "Plank")
+    }
+
+    @Test func swapExercise_tracksOriginalName() throws {
+        let container = try makeTestContainer()
+        let context = container.mainContext
+
+        let session = WorkoutSession()
+        context.insert(session)
+
+        let log = ExerciseLog(exerciseName: "Squat", sortOrder: 0)
+        log.session = session
+        context.insert(log)
+        try context.save()
+
+        let engine = WorkoutEngine(modelContext: context)
+        engine.resumeSession(session, previous: nil)
+
+        engine.swapExercise(log, with: ExerciseTemplate(name: "Leg Press", category: "Legs", defaultSets: 3, defaultReps: 12))
+
+        #expect(log.swappedFromExercise == "Squat")
+
+        // Swap again
+        engine.swapExercise(log, with: ExerciseTemplate(name: "Hack Squat", category: "Legs", defaultSets: 3, defaultReps: 10))
+
+        // Should still track the ORIGINAL exercise name
+        #expect(log.swappedFromExercise == "Squat")
+    }
+}


### PR DESCRIPTION
## Summary

### Reorder Exercises (F2)
- Toolbar reorder button (↑↓) opens a sheet with drag-to-reorder list
- `WorkoutEngine.reorderExercises(from:to:)` updates `ExerciseLog.sortOrder`
- **Session-scoped only** — workout plan is NOT modified

### Exercise Swap (F3)
- Context menu on exercise name: "Swap Exercise" opens exercise picker
- `WorkoutEngine.swapExercise(_:with:)` changes name, updates isIsometric, clears PR flags
- Preserves all existing sets (weights, reps, completion status)
- Tracks original exercise via `ExerciseLog.swappedFromExercise`
- Multiple swaps retain the ORIGINAL exercise name

### Visual Indicators
- Swapped exercises show orange "from [Original]" with swap icon
- Visible in both active workout and session detail history

## Changes
- **ExerciseLog**: added `swappedFromExercise: String`
- **WorkoutEngine**: added `reorderExercises()` and `swapExercise()` methods
- **ActiveWorkoutView**: reorder sheet, swap context menu, swap indicator
- **WorkoutSessionDetailView**: swap indicator in history

## Test plan
- [x] 8 new tests pass (reorder: 3, swap: 5)
- [ ] CI passes
- [ ] Reorder: tap ↑↓ → drag exercises → verify new order persists
- [ ] Swap: long-press exercise → Swap → pick alternative → verify sets preserved
- [ ] Swap: verify "from [Original]" indicator appears
- [ ] Swap: verify PR flags cleared after swap

Closes #19