### PR TITLE
feat: workout session UX — auto-fill, skip inter-exercise timer, progress bar

### DIFF
--- a/OneTrack/Engine/WorkoutEngine.swift
+++ b/OneTrack/Engine/WorkoutEngine.swift
@@ -168,6 +168,36 @@ final class WorkoutEngine {
         try? modelContext.save()
     }
 
+    // MARK: - Auto-fill
+
+    /// After completing a set, auto-populate the next uncompleted set in the same
+    /// exercise with the same weight and reps/seconds. Does NOT overwrite user-entered values.
+    func autoFillNextSet(in log: ExerciseLog, afterSet completedSet: SetLog) {
+        let sorted = log.sets.sorted { $0.setNumber < $1.setNumber }
+        guard let nextSet = sorted.first(where: { !$0.isCompleted && $0.setNumber > completedSet.setNumber }) else {
+            return
+        }
+        if nextSet.weightKg == 0 {
+            nextSet.weightKg = completedSet.weightKg
+        }
+        if log.isIsometric {
+            if nextSet.seconds == 0 {
+                nextSet.seconds = completedSet.seconds
+            }
+        } else {
+            if nextSet.reps == 0 {
+                nextSet.reps = completedSet.reps
+            }
+        }
+    }
+
+    /// Returns true if the rest timer should fire after completing a set.
+    /// Skips the timer if the completed set is the last set in its exercise log.
+    func shouldStartRestTimer(in log: ExerciseLog, afterSet completedSet: SetLog) -> Bool {
+        let sorted = log.sets.sorted { $0.setNumber < $1.setNumber }
+        return sorted.last?.setNumber != completedSet.setNumber
+    }
+
     // MARK: - Rest Timer
 
     func startRestTimer(duration: Int? = nil) {

--- a/OneTrack/Views/Workouts/ActiveWorkoutView.swift
+++ b/OneTrack/Views/Workouts/ActiveWorkoutView.swift
@@ -64,8 +64,11 @@ struct ActiveWorkoutView: View {
                                 log: log,
                                 previousSession: previousSession,
                                 modelContext: modelContext,
-                                onSetCompleted: {
-                                    startRestTimer(duration: exerciseRestSeconds)
+                                onSetCompleted: { completedSet in
+                                    engine?.autoFillNextSet(in: log, afterSet: completedSet)
+                                    if engine?.shouldStartRestTimer(in: log, afterSet: completedSet) == true {
+                                        startRestTimer(duration: exerciseRestSeconds)
+                                    }
                                 },
                                 onPRDetected: {
                                     triggerPRCelebration()
@@ -262,6 +265,17 @@ struct ActiveWorkoutView: View {
                         .foregroundStyle(.blue)
                 }
             }
+
+            // Linear progress bar
+            VStack(spacing: 4) {
+                ProgressView(value: progress)
+                    .tint(.blue)
+                    .animation(.easeInOut(duration: 0.3), value: progress)
+
+                Text("\(completedCount) of \(totalCount) working sets")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
         }
         .cardStyle()
     }
@@ -379,7 +393,7 @@ private struct ExerciseSectionView: View {
     let log: ExerciseLog
     let previousSession: WorkoutSession?
     let modelContext: ModelContext
-    let onSetCompleted: () -> Void
+    let onSetCompleted: (SetLog) -> Void
     let onPRDetected: () -> Void
     let onAddSet: () -> Void
     let onDeleteSet: (SetLog) -> Void
@@ -533,7 +547,7 @@ private struct ExerciseSectionView: View {
                     isIsometric: log.isIsometric,
                     exerciseName: log.exerciseName,
                     modelContext: modelContext,
-                    onCompleted: onSetCompleted,
+                    onCompleted: { onSetCompleted(setLog) },
                     onPRDetected: onPRDetected
                 )
                 .contextMenu {

--- a/OneTrackTests/Engine/WorkoutEngineTests.swift
+++ b/OneTrackTests/Engine/WorkoutEngineTests.swift
@@ -152,4 +152,195 @@ struct WorkoutEngineTests {
         // 60 * (1 + 10/30) = 80
         #expect(result == 80.0)
     }
+
+    // MARK: - Auto-fill
+
+    @Test func autoFillNextSet_copiesWeightAndReps() throws {
+        let (engine, context) = try makeEngine()
+
+        let log = ExerciseLog(exerciseName: "Bench", sortOrder: 0)
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 8, weightKg: 60)
+        set1.isCompleted = true
+        set1.exerciseLog = log
+        context.insert(set1)
+
+        let set2 = SetLog(setNumber: 2, reps: 0, weightKg: 0)
+        set2.exerciseLog = log
+        context.insert(set2)
+
+        try context.save()
+
+        engine.autoFillNextSet(in: log, afterSet: set1)
+
+        #expect(set2.reps == 8)
+        #expect(set2.weightKg == 60)
+    }
+
+    @Test func autoFillNextSet_doesNotOverwriteUserValues() throws {
+        let (engine, context) = try makeEngine()
+
+        let log = ExerciseLog(exerciseName: "Squat", sortOrder: 0)
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 10, weightKg: 80)
+        set1.isCompleted = true
+        set1.exerciseLog = log
+        context.insert(set1)
+
+        let set2 = SetLog(setNumber: 2, reps: 5, weightKg: 70)
+        set2.exerciseLog = log
+        context.insert(set2)
+
+        try context.save()
+
+        engine.autoFillNextSet(in: log, afterSet: set1)
+
+        #expect(set2.reps == 5)
+        #expect(set2.weightKg == 70)
+    }
+
+    @Test func autoFillNextSet_skipsCompletedSets() throws {
+        let (engine, context) = try makeEngine()
+
+        let log = ExerciseLog(exerciseName: "Row", sortOrder: 0)
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 8, weightKg: 50)
+        set1.isCompleted = true
+        set1.exerciseLog = log
+        context.insert(set1)
+
+        let set2 = SetLog(setNumber: 2, reps: 8, weightKg: 50)
+        set2.isCompleted = true
+        set2.exerciseLog = log
+        context.insert(set2)
+
+        let set3 = SetLog(setNumber: 3, reps: 0, weightKg: 0)
+        set3.exerciseLog = log
+        context.insert(set3)
+
+        try context.save()
+
+        engine.autoFillNextSet(in: log, afterSet: set1)
+
+        #expect(set3.reps == 8)
+        #expect(set3.weightKg == 50)
+    }
+
+    @Test func autoFillNextSet_isometricCopiesSeconds() throws {
+        let (engine, context) = try makeEngine()
+
+        let log = ExerciseLog(exerciseName: "Plank", sortOrder: 0, isIsometric: true)
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 0, seconds: 45, weightKg: 10)
+        set1.isCompleted = true
+        set1.exerciseLog = log
+        context.insert(set1)
+
+        let set2 = SetLog(setNumber: 2, reps: 0, seconds: 0, weightKg: 0)
+        set2.exerciseLog = log
+        context.insert(set2)
+
+        try context.save()
+
+        engine.autoFillNextSet(in: log, afterSet: set1)
+
+        #expect(set2.seconds == 45)
+        #expect(set2.weightKg == 10)
+    }
+
+    @Test func autoFillNextSet_noopWhenLastSet() throws {
+        let (engine, context) = try makeEngine()
+
+        let log = ExerciseLog(exerciseName: "Curl", sortOrder: 0)
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 10, weightKg: 15)
+        set1.isCompleted = true
+        set1.exerciseLog = log
+        context.insert(set1)
+
+        try context.save()
+
+        engine.autoFillNextSet(in: log, afterSet: set1)
+        // No crash, no side effects
+    }
+
+    // MARK: - Skip inter-exercise timer
+
+    @Test func shouldStartRestTimer_trueForMidExerciseSet() throws {
+        let (engine, context) = try makeEngine()
+
+        let log = ExerciseLog(exerciseName: "Bench", sortOrder: 0)
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 8, weightKg: 60)
+        set1.exerciseLog = log
+        context.insert(set1)
+
+        let set2 = SetLog(setNumber: 2, reps: 8, weightKg: 60)
+        set2.exerciseLog = log
+        context.insert(set2)
+
+        try context.save()
+
+        #expect(engine.shouldStartRestTimer(in: log, afterSet: set1) == true)
+    }
+
+    @Test func shouldStartRestTimer_falseForLastSetOfExercise() throws {
+        let (engine, context) = try makeEngine()
+
+        let log = ExerciseLog(exerciseName: "Bench", sortOrder: 0)
+        context.insert(log)
+
+        let set1 = SetLog(setNumber: 1, reps: 8, weightKg: 60)
+        set1.exerciseLog = log
+        context.insert(set1)
+
+        let set2 = SetLog(setNumber: 2, reps: 8, weightKg: 60)
+        set2.exerciseLog = log
+        context.insert(set2)
+
+        try context.save()
+
+        #expect(engine.shouldStartRestTimer(in: log, afterSet: set2) == false)
+    }
+
+    // MARK: - Progress excludes warm-ups
+
+    @Test func progress_excludesWarmUpSets() throws {
+        let (engine, context) = try makeEngine()
+
+        let session = WorkoutSession()
+        context.insert(session)
+
+        let log = ExerciseLog(exerciseName: "Squat", sortOrder: 0)
+        log.session = session
+        context.insert(log)
+
+        let warmUp = SetLog(setNumber: 1, reps: 5, weightKg: 40, setType: .warmUp)
+        warmUp.isCompleted = true
+        warmUp.exerciseLog = log
+        context.insert(warmUp)
+
+        let working1 = SetLog(setNumber: 2, reps: 5, weightKg: 100)
+        working1.isCompleted = true
+        working1.exerciseLog = log
+        context.insert(working1)
+
+        let working2 = SetLog(setNumber: 3, reps: 5, weightKg: 100)
+        working2.exerciseLog = log
+        context.insert(working2)
+
+        try context.save()
+
+        engine.resumeSession(session, previous: nil)
+
+        #expect(engine.completedCount == 1)
+        #expect(engine.totalCount == 2)
+        #expect(engine.progress == 0.5)
+    }
 }


### PR DESCRIPTION
## Summary

- **Weight/reps auto-fill**: After completing a set, the next uncompleted set in the same exercise is auto-populated with the same weight and reps/seconds. Does not overwrite user-entered values.
- **Skip inter-exercise timer**: Rest timer only fires between sets of the same exercise. If the completed set is the last in its ExerciseLog, the timer is skipped.
- **Progress bar**: Added a linear progress bar in the header card showing completed vs total working sets (warm-ups excluded).

## Files changed

- `OneTrack/Engine/WorkoutEngine.swift` — `autoFillNextSet(in:afterSet:)` and `shouldStartRestTimer(in:afterSet:)` methods
- `OneTrack/Views/Workouts/ActiveWorkoutView.swift` — wired auto-fill + skip logic into `onSetCompleted`, added `ProgressView` to header
- `OneTrackTests/Engine/WorkoutEngineTests.swift` — 8 new tests covering auto-fill, timer skip, and progress computation

## Test plan

- [ ] Complete a set mid-exercise → verify next set auto-fills with same weight/reps
- [ ] Pre-enter values on next set, complete current → verify pre-entered values preserved
- [ ] Complete last set of an exercise → verify no rest timer fires
- [ ] Complete a non-last set → verify rest timer fires normally
- [ ] Check progress bar updates as sets are completed
- [ ] Verify warm-up sets excluded from progress count
- [ ] Run unit tests: `xcodebuild test -scheme OneTrack`

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)